### PR TITLE
Fix MIN_SECONDS_BETWEEN_OPS and MAX_USES_PER_BOOT tags logic

### DIFF
--- a/keymaster/ta/include/operations.h
+++ b/keymaster/ta/include/operations.h
@@ -26,6 +26,7 @@
 
 #include "ta_ca_defs.h"
 #include "tables.h"
+#include "master_crypto.h"
 
 typedef struct keymaster_blob_list_item_t {
 	keymaster_blob_t data;
@@ -33,6 +34,7 @@ typedef struct keymaster_blob_list_item_t {
 } keymaster_blob_list_item_t;
 
 typedef struct {
+	uint8_t key_id[TAG_LENGTH];
 	keymaster_key_blob_t *key;
 	keymaster_blob_t nonce;
 	keymaster_blob_t last_block;
@@ -71,7 +73,8 @@ keymaster_error_t TA_try_start_operation(
 				const keymaster_block_mode_t mode,
 				const uint32_t mac_length,
 				const keymaster_digest_t digest,
-				const keymaster_blob_t nonce);
+				const keymaster_blob_t nonce,
+				uint8_t *key_id);
 
 keymaster_error_t TA_start_operation(
 				const keymaster_operation_handle_t op_handle,
@@ -85,7 +88,8 @@ keymaster_error_t TA_start_operation(
 				const keymaster_block_mode_t mode,
 				const uint32_t mac_length,
 				const keymaster_digest_t digest,
-				const keymaster_blob_t nonce);
+				const keymaster_blob_t nonce,
+				uint8_t *key_id);
 
 keymaster_error_t TA_get_operation(const keymaster_operation_handle_t op_handle,
 				keymaster_operation_t *operation);

--- a/keymaster/ta/include/parameters.h
+++ b/keymaster/ta/include/parameters.h
@@ -60,7 +60,7 @@ keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
 				keymaster_padding_t *padding,
 				uint32_t *mac_length,
 				keymaster_blob_t *nonce, uint32_t *min_sec,
-				bool *do_auth);
+				bool *do_auth, uint8_t *key_id);
 
 void TA_push_param(keymaster_key_param_set_t *params,
 			const keymaster_key_param_t *param);

--- a/keymaster/ta/include/parameters.h
+++ b/keymaster/ta/include/parameters.h
@@ -50,8 +50,7 @@ keymaster_error_t TA_check_permission(const keymaster_key_param_set_t *params,
 				const keymaster_blob_t app_data,
 				bool *exportable);
 
-keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
-				const keymaster_key_param_set_t *key_params,
+keymaster_error_t TA_check_params(const keymaster_key_param_set_t *key_params,
 				const keymaster_key_param_set_t *in_params,
 				keymaster_algorithm_t *algorithm,
 				const keymaster_purpose_t op_purpose,

--- a/keymaster/ta/include/tables.h
+++ b/keymaster/ta/include/tables.h
@@ -19,7 +19,7 @@
 #define ANDROID_OPTEE_TABLES_H
 
 #define KM_MAX_USE_COUNTERS 20U
-#define KM_MAX_USE_TIMERS 30U
+#define KM_MAX_USE_TIMERS 32U
 #define UNDEFINED UINT32_MAX
 
 #include <tee_internal_api.h>
@@ -27,6 +27,7 @@
 #include <utee_defines.h>
 
 #include "ta_ca_defs.h"
+#include "master_crypto.h"
 
 typedef struct {
 	keymaster_key_blob_t key;
@@ -34,7 +35,7 @@ typedef struct {
 } keymaster_use_counter_t;
 
 typedef struct {
-	keymaster_key_blob_t key;
+	uint8_t key_id[TAG_LENGTH];
 	TEE_Time last_access;
 	uint32_t min_sec;
 } keymaster_use_timer_t;
@@ -42,12 +43,9 @@ typedef struct {
 keymaster_error_t TA_count_key_uses(const keymaster_key_blob_t key,
 				const uint32_t max_uses);
 
-void TA_clean_timers(void);
+keymaster_error_t TA_trigger_timer(uint8_t *key_id);
 
-keymaster_error_t TA_trigger_timer(const keymaster_key_blob_t *key,
-				const uint32_t min_sec);
-
-keymaster_error_t TA_check_key_use_timer(const keymaster_key_blob_t *key,
+keymaster_error_t TA_check_key_use_timer(uint8_t *key_id,
 				const uint32_t min_sec);
 
 #endif/* ANDROID_OPTEE_TABLES_H */

--- a/keymaster/ta/include/tables.h
+++ b/keymaster/ta/include/tables.h
@@ -30,7 +30,7 @@
 #include "master_crypto.h"
 
 typedef struct {
-	keymaster_key_blob_t key;
+	uint8_t key_id[TAG_LENGTH];
 	uint32_t count;
 } keymaster_use_counter_t;
 
@@ -40,7 +40,7 @@ typedef struct {
 	uint32_t min_sec;
 } keymaster_use_timer_t;
 
-keymaster_error_t TA_count_key_uses(const keymaster_key_blob_t key,
+keymaster_error_t TA_count_key_uses(uint8_t *key_id,
 				const uint32_t max_uses);
 
 keymaster_error_t TA_trigger_timer(uint8_t *key_id);

--- a/keymaster/ta/keystore_ta.c
+++ b/keymaster/ta/keystore_ta.c
@@ -1073,7 +1073,7 @@ static keymaster_error_t TA_begin(TEE_Param params[TEE_NUM_PARAMS])
 	key_material = TEE_Malloc(key.key_material_size, TEE_MALLOC_FILL_ZERO);
 
 	memcpy(key_id, key.key_material + key.key_material_size - TAG_LENGTH,
-		TAG_LENGTH);
+	       TAG_LENGTH);
 
 	res = TA_restore_key(key_material, &key, &key_size,
 						 &type, &obj_h, &params_t);
@@ -1092,7 +1092,7 @@ static keymaster_error_t TA_begin(TEE_Param params[TEE_NUM_PARAMS])
 	default:/* HMAC */
 		algorithm = KM_ALGORITHM_HMAC;
 	}
-	res = TA_check_params(&key, &params_t, &in_params,
+	res = TA_check_params(&params_t, &in_params,
 				&algorithm, purpose, &digest, &mode,
 				&padding, &mac_length, &nonce,
 				&min_sec, &do_auth, key_id);
@@ -1142,9 +1142,9 @@ static keymaster_error_t TA_begin(TEE_Param params[TEE_NUM_PARAMS])
 			goto out;
 	}
 	res = TA_start_operation(operation_handle, key, min_sec,
-					operation, purpose, digest_op, do_auth,
-					padding, mode, mac_length, digest,
-					nonce, key_id);
+				 operation, purpose, digest_op, do_auth,
+				 padding, mode, mac_length, digest,
+				 nonce, key_id);
 	if (res != KM_ERROR_OK)
 		goto out;
 

--- a/keymaster/ta/operations.c
+++ b/keymaster/ta/operations.c
@@ -87,7 +87,8 @@ keymaster_error_t TA_abort_operation(
 				TEE_Free(operations[i].last_block.data);
 			operations[i].last_block.data = NULL;
 			operations[i].last_block.data_length = 0;
-			TEE_MemFill(operations[i].key_id, 0, sizeof(operations[i].key_id));
+			TEE_MemFill(operations[i].key_id, 0,
+				    sizeof(operations[i].key_id));
 			break;
 		}
 	}
@@ -121,7 +122,8 @@ void TA_reset_operations_table(void)
 		operations[i].last_block.data_length = 0;
 		operations[i].first = true;
 		operations[i].padded = false;
-		TEE_MemFill(operations[i].key_id, 0, sizeof(operations[i].key_id));
+		TEE_MemFill(operations[i].key_id, 0,
+			    sizeof(operations[i].key_id));
 	}
 }
 
@@ -231,20 +233,20 @@ keymaster_error_t TA_start_operation(
 				uint8_t *key_id)
 {
 	keymaster_error_t res = TA_try_start_operation(op_handle, key, min_sec,
-							operation, purpose,
-							digest_op, do_auth,
-							padding, mode,
-							mac_length, digest,
-							nonce, key_id);
+						       operation, purpose,
+						       digest_op, do_auth,
+						       padding, mode,
+						       mac_length, digest,
+						       nonce, key_id);
 	if (res != KM_ERROR_OK) {
 		res = TA_kill_old_operation();
 		if (res == KM_ERROR_OK) {
 			res = TA_try_start_operation(op_handle, key, min_sec,
-							operation, purpose,
-							digest_op, do_auth,
-							padding, mode,
-							mac_length, digest,
-							nonce, key_id);
+						     operation, purpose,
+						     digest_op, do_auth,
+						     padding, mode,
+						     mac_length, digest,
+						     nonce, key_id);
 		}
 	}
 	return res;

--- a/keymaster/ta/parameters.c
+++ b/keymaster/ta/parameters.c
@@ -581,7 +581,8 @@ keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
 				keymaster_padding_t *op_padding,
 				uint32_t *mac_length,
 				keymaster_blob_t *nonce,
-				uint32_t *min_sec, bool *do_auth)
+				uint32_t *min_sec, bool *do_auth,
+				uint8_t *key_id)
 {
 	hw_auth_token_t auth_token;
 	hw_authenticator_type_t auth_type = HW_AUTH_NONE;
@@ -1038,7 +1039,7 @@ keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
 		}
 	}
 	if (*min_sec != UNDEFINED) {
-		res = TA_check_key_use_timer(key, *min_sec);
+		res = TA_check_key_use_timer(key_id, *min_sec);
 		if (res != KM_ERROR_OK)
 			goto out_cp;
 	}

--- a/keymaster/ta/parameters.c
+++ b/keymaster/ta/parameters.c
@@ -571,8 +571,7 @@ bool cmpBlobParam(const keymaster_blob_t blob,
 		blob.data_length);
 }
 
-keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
-				const keymaster_key_param_set_t *key_params,
+keymaster_error_t TA_check_params(const keymaster_key_param_set_t *key_params,
 				const keymaster_key_param_set_t *in_params,
 				keymaster_algorithm_t *algorithm,
 				const keymaster_purpose_t op_purpose,
@@ -1044,7 +1043,7 @@ keymaster_error_t TA_check_params(keymaster_key_blob_t *key,
 			goto out_cp;
 	}
 	if (max_uses != UNDEFINED) {
-		res = TA_count_key_uses(*key, max_uses);
+		res = TA_count_key_uses(key_id, max_uses);
 		if (res != KM_ERROR_OK)
 			goto out_cp;
 	}

--- a/keymaster/ta/tables.c
+++ b/keymaster/ta/tables.c
@@ -16,10 +16,48 @@
  */
 
 #include "tables.h"
+#include "assert.h"
 
 static keymaster_use_timer_t use_timers[KM_MAX_USE_TIMERS];
 static keymaster_use_counter_t use_counters[KM_MAX_USE_COUNTERS];
-static uint32_t in_use_c;
+static uint32_t in_use_c = 0;
+
+
+/*
+ * This function assumes that keyst from this table are not
+ * to be deleted during TA lifetime
+ */
+keymaster_error_t TA_count_key_uses(uint8_t *key_id,
+				    const uint32_t max_uses)
+{
+	uint32_t free_n = in_use_c;
+
+	assert(in_use_c <= KM_MAX_USE_COUNTERS);
+
+	for (uint32_t i = 0; i < in_use_c; i++) {
+		if (TEE_MemCompare(key_id, use_counters[i].key_id,
+				   sizeof(use_counters[i].key_id)))
+			continue;
+
+		if (use_counters[i].count < max_uses) {
+		    use_counters[i].count++;
+			return KM_ERROR_OK;
+		}
+
+		EMSG("Reached max key use count!");
+		return KM_ERROR_KEY_MAX_OPS_EXCEEDED;
+	}
+
+	if (in_use_c == KM_MAX_USE_COUNTERS)
+	    return KM_ERROR_TOO_MANY_OPERATIONS;
+
+	memcpy(use_counters[free_n].key_id, key_id,
+	       sizeof(use_counters[free_n].key_id));
+	use_counters[free_n].count  = 1;
+	in_use_c++;
+
+	return KM_ERROR_OK;
+}
 
 static void clean_timers(void)
 {
@@ -28,11 +66,11 @@ static void clean_timers(void)
 	TEE_GetSystemTime(&cur_t);
 	for (uint32_t i = 0; i < KM_MAX_USE_TIMERS; i++) {
 		if (use_timers[i].last_access.seconds != 0 &&
-			    (cur_t.seconds >=
-			    use_timers[i].last_access.seconds +
-			    use_timers[i].min_sec)) {
-			TEE_MemFill(use_timers[i].key_id, 0,
-					sizeof(use_timers[i].key_id));
+		    (cur_t.seconds >=
+		    use_timers[i].last_access.seconds +
+		    use_timers[i].min_sec)) {
+		    TEE_MemFill(use_timers[i].key_id, 0,
+				sizeof(use_timers[i].key_id));
 			use_timers[i].min_sec = 0;
 			use_timers[i].last_access.seconds = 0;
 			use_timers[i].last_access.millis = 0;
@@ -40,37 +78,27 @@ static void clean_timers(void)
 	}
 }
 
-keymaster_error_t TA_count_key_uses(const keymaster_key_blob_t key,
-				const uint32_t max_uses)
+keymaster_error_t TA_trigger_timer(uint8_t *key_id)
 {
-	if (in_use_c < KM_MAX_USE_COUNTERS) {
-		use_counters[in_use_c].key = key;
-		use_counters[in_use_c].count = 0;
-		in_use_c++;
-	} else {
-		return KM_ERROR_TOO_MANY_OPERATIONS;
-	}
+	TEE_Time cur_t;
 
-	for (uint32_t i = 0; i < in_use_c; i++) {
-		if (key.key_material_size !=
-				use_counters[i].key.key_material_size)
-			continue;
-		if (!TEE_MemCompare(key.key_material,
-				use_counters[i].key.key_material,
-				key.key_material_size)) {
-			if (use_counters[i].count < max_uses) {
-				use_counters[i].count++;
-				break;
-			}
-			EMSG("Reached max key use count!");
-			return KM_ERROR_KEY_MAX_OPS_EXCEEDED;
+	clean_timers();
+	TEE_GetSystemTime(&cur_t);
+
+	for (uint32_t i = 0; i < KM_MAX_USE_TIMERS; i++) {
+		if (!TEE_MemCompare(key_id,
+				    use_timers[i].key_id,
+				    sizeof (use_timers[i].key_id))) {
+			use_timers[i].last_access = cur_t;
+			return KM_ERROR_OK;
 		}
 	}
+
 	return KM_ERROR_OK;
 }
 
 keymaster_error_t TA_check_key_use_timer(uint8_t *key_id,
-					const uint32_t min_sec)
+					 const uint32_t min_sec)
 {
 	TEE_Time cur_t;
 	uint32_t free_n = KM_MAX_USE_TIMERS;
@@ -79,15 +107,15 @@ keymaster_error_t TA_check_key_use_timer(uint8_t *key_id,
 	TEE_GetSystemTime(&cur_t);
 	for (uint32_t i = 0; i < KM_MAX_USE_TIMERS; i++) {
 		if (free_n == KM_MAX_USE_TIMERS &&
-			use_timers[i].min_sec == 0) {
-			free_n = i;
+		    use_timers[i].min_sec == 0) {
+		    free_n = i;
 		}
 
 		if (!TEE_MemCompare(key_id,
-				use_timers[i].key_id,
-				sizeof(use_timers[i].key_id))) {
+				    use_timers[i].key_id,
+				    sizeof(use_timers[i].key_id))) {
 			if (use_timers[i].last_access.seconds +
-						min_sec > cur_t.seconds) {
+			    min_sec > cur_t.seconds) {
 				return KM_ERROR_KEY_RATE_LIMIT_EXCEEDED;
 			}
 			return KM_ERROR_OK;
@@ -100,27 +128,8 @@ keymaster_error_t TA_check_key_use_timer(uint8_t *key_id,
 	}
 
 	memcpy(use_timers[free_n].key_id, key_id,
-		sizeof(use_timers[free_n].key_id));
+	       sizeof(use_timers[free_n].key_id));
 	use_timers[free_n].min_sec = min_sec;
-
-	return KM_ERROR_OK;
-}
-
-keymaster_error_t TA_trigger_timer(uint8_t *key_id)
-{
-	TEE_Time cur_t;
-
-	clean_timers();
-	TEE_GetSystemTime(&cur_t);
-
-	for (uint32_t i = 0; i < KM_MAX_USE_TIMERS; i++) {
-		if (!TEE_MemCompare(key_id,
-				use_timers[i].key_id,
-				sizeof (use_timers[i].key_id))) {
-			use_timers[i].last_access = cur_t;
-			return KM_ERROR_OK;
-		}
-	}
 
 	return KM_ERROR_OK;
 }

--- a/test/functional/Android.bp
+++ b/test/functional/Android.bp
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2017 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissiKMGK_gtestns and
+// limitations under the License.
+//
+
+cc_test {
+    name: "KMGK_gtest",
+    defaults: ["VtsHalTargetTestDefaults"],
+    srcs: [
+        "authorization_set.cpp",
+        "attestation_record.cpp",
+        "key_param_output.cpp",
+        "keymaster_hidl_hal_test.cpp",
+        "keystore_tags_utils.cpp",
+    ],
+    static_libs: [
+        "android.hardware.keymaster@3.0",
+        "libcrypto",
+        "libsoftkeymasterdevice",
+    ],
+}

--- a/test/functional/attestation_record.cpp
+++ b/test/functional/attestation_record.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "attestation_record.h"
+
+#include <assert.h>
+
+#include <openssl/asn1t.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+
+#include "openssl_utils.h"
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+struct stack_st_ASN1_TYPE_Delete {
+    void operator()(stack_st_ASN1_TYPE* p) { sk_ASN1_TYPE_free(p); }
+};
+
+struct ASN1_STRING_Delete {
+    void operator()(ASN1_STRING* p) { ASN1_STRING_free(p); }
+};
+
+struct ASN1_TYPE_Delete {
+    void operator()(ASN1_TYPE* p) { ASN1_TYPE_free(p); }
+};
+
+#define ASN1_INTEGER_SET STACK_OF(ASN1_INTEGER)
+
+typedef struct km_root_of_trust {
+    ASN1_OCTET_STRING* verified_boot_key;
+    ASN1_BOOLEAN* device_locked;
+    ASN1_ENUMERATED* verified_boot_state;
+} KM_ROOT_OF_TRUST;
+
+ASN1_SEQUENCE(KM_ROOT_OF_TRUST) = {
+    ASN1_SIMPLE(KM_ROOT_OF_TRUST, verified_boot_key, ASN1_OCTET_STRING),
+    ASN1_SIMPLE(KM_ROOT_OF_TRUST, device_locked, ASN1_BOOLEAN),
+    ASN1_SIMPLE(KM_ROOT_OF_TRUST, verified_boot_state, ASN1_ENUMERATED),
+} ASN1_SEQUENCE_END(KM_ROOT_OF_TRUST);
+IMPLEMENT_ASN1_FUNCTIONS(KM_ROOT_OF_TRUST);
+
+typedef struct km_auth_list {
+    ASN1_INTEGER_SET* purpose;
+    ASN1_INTEGER* algorithm;
+    ASN1_INTEGER* key_size;
+    ASN1_INTEGER_SET* digest;
+    ASN1_INTEGER_SET* padding;
+    ASN1_INTEGER_SET* kdf;
+    ASN1_INTEGER* ec_curve;
+    ASN1_INTEGER* rsa_public_exponent;
+    ASN1_INTEGER* active_date_time;
+    ASN1_INTEGER* origination_expire_date_time;
+    ASN1_INTEGER* usage_expire_date_time;
+    ASN1_NULL* no_auth_required;
+    ASN1_INTEGER* user_auth_type;
+    ASN1_INTEGER* auth_timeout;
+    ASN1_NULL* allow_while_on_body;
+    ASN1_NULL* all_applications;
+    ASN1_OCTET_STRING* application_id;
+    ASN1_INTEGER* creation_date_time;
+    ASN1_INTEGER* origin;
+    ASN1_NULL* rollback_resistant;
+    KM_ROOT_OF_TRUST* root_of_trust;
+    ASN1_INTEGER* os_version;
+    ASN1_INTEGER* os_patchlevel;
+    ASN1_OCTET_STRING* attestation_application_id;
+} KM_AUTH_LIST;
+
+ASN1_SEQUENCE(KM_AUTH_LIST) = {
+    ASN1_EXP_SET_OF_OPT(KM_AUTH_LIST, purpose, ASN1_INTEGER, TAG_PURPOSE.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, algorithm, ASN1_INTEGER, TAG_ALGORITHM.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, key_size, ASN1_INTEGER, TAG_KEY_SIZE.maskedTag()),
+    ASN1_EXP_SET_OF_OPT(KM_AUTH_LIST, digest, ASN1_INTEGER, TAG_DIGEST.maskedTag()),
+    ASN1_EXP_SET_OF_OPT(KM_AUTH_LIST, padding, ASN1_INTEGER, TAG_PADDING.maskedTag()),
+    ASN1_EXP_SET_OF_OPT(KM_AUTH_LIST, kdf, ASN1_INTEGER, TAG_KDF.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, ec_curve, ASN1_INTEGER, TAG_EC_CURVE.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, rsa_public_exponent, ASN1_INTEGER,
+                 TAG_RSA_PUBLIC_EXPONENT.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, active_date_time, ASN1_INTEGER, TAG_ACTIVE_DATETIME.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, origination_expire_date_time, ASN1_INTEGER,
+                 TAG_ORIGINATION_EXPIRE_DATETIME.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, usage_expire_date_time, ASN1_INTEGER,
+                 TAG_USAGE_EXPIRE_DATETIME.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, no_auth_required, ASN1_NULL, TAG_NO_AUTH_REQUIRED.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, user_auth_type, ASN1_INTEGER, TAG_USER_AUTH_TYPE.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, auth_timeout, ASN1_INTEGER, TAG_AUTH_TIMEOUT.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, allow_while_on_body, ASN1_NULL, TAG_ALLOW_WHILE_ON_BODY.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, all_applications, ASN1_NULL, TAG_ALL_APPLICATIONS.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, application_id, ASN1_OCTET_STRING, TAG_APPLICATION_ID.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, creation_date_time, ASN1_INTEGER, TAG_CREATION_DATETIME.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, origin, ASN1_INTEGER, TAG_ORIGIN.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, rollback_resistant, ASN1_NULL, TAG_ROLLBACK_RESISTANT.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, root_of_trust, KM_ROOT_OF_TRUST, TAG_ROOT_OF_TRUST.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, os_version, ASN1_INTEGER, TAG_OS_VERSION.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, os_patchlevel, ASN1_INTEGER, TAG_OS_PATCHLEVEL.maskedTag()),
+    ASN1_EXP_OPT(KM_AUTH_LIST, attestation_application_id, ASN1_OCTET_STRING,
+                 TAG_ATTESTATION_APPLICATION_ID.maskedTag()),
+} ASN1_SEQUENCE_END(KM_AUTH_LIST);
+IMPLEMENT_ASN1_FUNCTIONS(KM_AUTH_LIST);
+
+typedef struct km_key_description {
+    ASN1_INTEGER* attestation_version;
+    ASN1_ENUMERATED* attestation_security_level;
+    ASN1_INTEGER* keymaster_version;
+    ASN1_ENUMERATED* keymaster_security_level;
+    ASN1_OCTET_STRING* attestation_challenge;
+    KM_AUTH_LIST* software_enforced;
+    KM_AUTH_LIST* tee_enforced;
+    ASN1_INTEGER* unique_id;
+} KM_KEY_DESCRIPTION;
+
+ASN1_SEQUENCE(KM_KEY_DESCRIPTION) = {
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, attestation_version, ASN1_INTEGER),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, attestation_security_level, ASN1_ENUMERATED),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, keymaster_version, ASN1_INTEGER),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, keymaster_security_level, ASN1_ENUMERATED),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, attestation_challenge, ASN1_OCTET_STRING),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, unique_id, ASN1_OCTET_STRING),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, software_enforced, KM_AUTH_LIST),
+    ASN1_SIMPLE(KM_KEY_DESCRIPTION, tee_enforced, KM_AUTH_LIST),
+} ASN1_SEQUENCE_END(KM_KEY_DESCRIPTION);
+IMPLEMENT_ASN1_FUNCTIONS(KM_KEY_DESCRIPTION);
+
+template <Tag tag>
+void copyAuthTag(const stack_st_ASN1_INTEGER* stack, TypedTag<TagType::ENUM_REP, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    typedef typename TypedTag2ValueType<decltype(ttag)>::type ValueT;
+    for (size_t i = 0; i < sk_ASN1_INTEGER_num(stack); ++i) {
+        auth_list->push_back(
+            ttag, static_cast<ValueT>(ASN1_INTEGER_get(sk_ASN1_INTEGER_value(stack, i))));
+    }
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_INTEGER* asn1_int, TypedTag<TagType::ENUM, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    typedef typename TypedTag2ValueType<decltype(ttag)>::type ValueT;
+    if (!asn1_int) return;
+    auth_list->push_back(ttag, static_cast<ValueT>(ASN1_INTEGER_get(asn1_int)));
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_INTEGER* asn1_int, TypedTag<TagType::UINT, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    if (!asn1_int) return;
+    auth_list->push_back(ttag, ASN1_INTEGER_get(asn1_int));
+}
+
+BIGNUM* construct_uint_max() {
+    BIGNUM* value = BN_new();
+    BIGNUM_Ptr one(BN_new());
+    BN_one(one.get());
+    BN_lshift(value, one.get(), 32);
+    return value;
+}
+
+uint64_t BignumToUint64(BIGNUM* num) {
+    static_assert((sizeof(BN_ULONG) == sizeof(uint32_t)) || (sizeof(BN_ULONG) == sizeof(uint64_t)),
+                  "This implementation only supports 32 and 64-bit BN_ULONG");
+    if (sizeof(BN_ULONG) == sizeof(uint32_t)) {
+        BIGNUM_Ptr uint_max(construct_uint_max());
+        BIGNUM_Ptr hi(BN_new()), lo(BN_new());
+        BN_CTX_Ptr ctx(BN_CTX_new());
+        BN_div(hi.get(), lo.get(), num, uint_max.get(), ctx.get());
+        return static_cast<uint64_t>(BN_get_word(hi.get())) << 32 | BN_get_word(lo.get());
+    } else if (sizeof(BN_ULONG) == sizeof(uint64_t)) {
+        return BN_get_word(num);
+    } else {
+        return 0;
+    }
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_INTEGER* asn1_int, TypedTag<TagType::ULONG, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    if (!asn1_int) return;
+    BIGNUM_Ptr num(ASN1_INTEGER_to_BN(asn1_int, nullptr));
+    auth_list->push_back(ttag, BignumToUint64(num.get()));
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_INTEGER* asn1_int, TypedTag<TagType::DATE, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    if (!asn1_int) return;
+    BIGNUM_Ptr num(ASN1_INTEGER_to_BN(asn1_int, nullptr));
+    auth_list->push_back(ttag, BignumToUint64(num.get()));
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_NULL* asn1_null, TypedTag<TagType::BOOL, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    if (!asn1_null) return;
+    auth_list->push_back(ttag);
+}
+
+template <Tag tag>
+void copyAuthTag(const ASN1_OCTET_STRING* asn1_string, TypedTag<TagType::BYTES, tag> ttag,
+                 AuthorizationSet* auth_list) {
+    if (!asn1_string) return;
+    hidl_vec<uint8_t> buf;
+    buf.setToExternal(asn1_string->data, asn1_string->length);
+    auth_list->push_back(ttag, buf);
+}
+
+// Extract the values from the specified ASN.1 record and place them in auth_list.
+static ErrorCode extract_auth_list(const KM_AUTH_LIST* record, AuthorizationSet* auth_list) {
+    if (!record) return ErrorCode::OK;
+
+    copyAuthTag(record->active_date_time, TAG_ACTIVE_DATETIME, auth_list);
+    copyAuthTag(record->algorithm, TAG_ALGORITHM, auth_list);
+    copyAuthTag(record->all_applications, TAG_ALL_APPLICATIONS, auth_list);
+    copyAuthTag(record->application_id, TAG_APPLICATION_ID, auth_list);
+    copyAuthTag(record->auth_timeout, TAG_AUTH_TIMEOUT, auth_list);
+    copyAuthTag(record->creation_date_time, TAG_CREATION_DATETIME, auth_list);
+    copyAuthTag(record->digest, TAG_DIGEST, auth_list);
+    copyAuthTag(record->ec_curve, TAG_EC_CURVE, auth_list);
+    copyAuthTag(record->key_size, TAG_KEY_SIZE, auth_list);
+    copyAuthTag(record->no_auth_required, TAG_NO_AUTH_REQUIRED, auth_list);
+    copyAuthTag(record->origin, TAG_ORIGIN, auth_list);
+    copyAuthTag(record->origination_expire_date_time, TAG_ORIGINATION_EXPIRE_DATETIME, auth_list);
+    copyAuthTag(record->os_patchlevel, TAG_OS_PATCHLEVEL, auth_list);
+    copyAuthTag(record->os_version, TAG_OS_VERSION, auth_list);
+    copyAuthTag(record->padding, TAG_PADDING, auth_list);
+    copyAuthTag(record->purpose, TAG_PURPOSE, auth_list);
+    copyAuthTag(record->rollback_resistant, TAG_ROLLBACK_RESISTANT, auth_list);
+    copyAuthTag(record->rsa_public_exponent, TAG_RSA_PUBLIC_EXPONENT, auth_list);
+    copyAuthTag(record->usage_expire_date_time, TAG_USAGE_EXPIRE_DATETIME, auth_list);
+    copyAuthTag(record->user_auth_type, TAG_USER_AUTH_TYPE, auth_list);
+    copyAuthTag(record->attestation_application_id,
+                TAG_ATTESTATION_APPLICATION_ID, auth_list);
+
+    return ErrorCode::OK;
+}
+
+MAKE_OPENSSL_PTR_TYPE(KM_KEY_DESCRIPTION)
+
+// Parse the DER-encoded attestation record, placing the results in keymaster_version,
+// attestation_challenge, software_enforced, tee_enforced and unique_id.
+ErrorCode parse_attestation_record(const uint8_t* asn1_key_desc, size_t asn1_key_desc_len,
+                                   uint32_t* attestation_version,  //
+                                   SecurityLevel* attestation_security_level,
+                                   uint32_t* keymaster_version,
+                                   SecurityLevel* keymaster_security_level,
+                                   hidl_vec<uint8_t>* attestation_challenge,
+                                   AuthorizationSet* software_enforced,
+                                   AuthorizationSet* tee_enforced,  //
+                                   hidl_vec<uint8_t>* unique_id) {
+    const uint8_t* p = asn1_key_desc;
+    KM_KEY_DESCRIPTION_Ptr record(d2i_KM_KEY_DESCRIPTION(nullptr, &p, asn1_key_desc_len));
+    if (!record.get()) return ErrorCode::UNKNOWN_ERROR;
+
+    *attestation_version = ASN1_INTEGER_get(record->attestation_version);
+    *attestation_security_level =
+        static_cast<SecurityLevel>(ASN1_ENUMERATED_get(record->attestation_security_level));
+    *keymaster_version = ASN1_INTEGER_get(record->keymaster_version);
+    *keymaster_security_level =
+        static_cast<SecurityLevel>(ASN1_ENUMERATED_get(record->keymaster_security_level));
+
+    auto& chall = record->attestation_challenge;
+    attestation_challenge->resize(chall->length);
+    memcpy(attestation_challenge->data(), chall->data, chall->length);
+    auto& uid = record->unique_id;
+    unique_id->resize(uid->length);
+    memcpy(unique_id->data(), uid->data, uid->length);
+
+    ErrorCode error = extract_auth_list(record->software_enforced, software_enforced);
+    if (error != ErrorCode::OK) return error;
+
+    return extract_auth_list(record->tee_enforced, tee_enforced);
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/attestation_record.h
+++ b/test/functional/attestation_record.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_ATTESTATION_RECORD_H_
+#define HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_ATTESTATION_RECORD_H_
+
+#include "authorization_set.h"
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+/**
+ * The OID for Android attestation records.  For the curious, it breaks down as follows:
+ *
+ * 1 = ISO
+ * 3 = org
+ * 6 = DoD (Huh? OIDs are weird.)
+ * 1 = IANA
+ * 4 = Private
+ * 1 = Enterprises
+ * 11129 = Google
+ * 2 = Google security
+ * 1 = certificate extension
+ * 17 = Android attestation extension.
+ */
+static const char kAttestionRecordOid[] = "1.3.6.1.4.1.11129.2.1.17";
+
+ErrorCode parse_attestation_record(const uint8_t* asn1_key_desc, size_t asn1_key_desc_len,
+                                   uint32_t* attestation_version,  //
+                                   SecurityLevel* attestation_security_level,
+                                   uint32_t* keymaster_version,
+                                   SecurityLevel* keymaster_security_level,
+                                   hidl_vec<uint8_t>* attestation_challenge,
+                                   AuthorizationSet* software_enforced,
+                                   AuthorizationSet* tee_enforced,  //
+                                   hidl_vec<uint8_t>* unique_id);
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android
+
+#endif  // HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_ATTESTATION_RECORD_H_

--- a/test/functional/authorization_set.cpp
+++ b/test/functional/authorization_set.cpp
@@ -1,0 +1,422 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "authorization_set.h"
+
+#include <assert.h>
+#include <istream>
+#include <limits>
+#include <ostream>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <new>
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+inline bool keyParamLess(const KeyParameter& a, const KeyParameter& b) {
+    if (a.tag != b.tag) return a.tag < b.tag;
+    int retval;
+    switch (typeFromTag(a.tag)) {
+    case TagType::INVALID:
+    case TagType::BOOL:
+        return false;
+    case TagType::ENUM:
+    case TagType::ENUM_REP:
+    case TagType::UINT:
+    case TagType::UINT_REP:
+        return a.f.integer < b.f.integer;
+    case TagType::ULONG:
+    case TagType::ULONG_REP:
+        return a.f.longInteger < b.f.longInteger;
+    case TagType::DATE:
+        return a.f.dateTime < b.f.dateTime;
+    case TagType::BIGNUM:
+    case TagType::BYTES:
+        // Handle the empty cases.
+        if (a.blob.size() == 0) return b.blob.size() != 0;
+        if (b.blob.size() == 0) return false;
+
+        retval = memcmp(&a.blob[0], &b.blob[0], std::min(a.blob.size(), b.blob.size()));
+        if (retval == 0) {
+            // One is the prefix of the other, so the longer wins
+            return a.blob.size() < b.blob.size();
+        } else {
+            return retval < 0;
+        }
+    }
+    return false;
+}
+
+inline bool keyParamEqual(const KeyParameter& a, const KeyParameter& b) {
+    if (a.tag != b.tag) return false;
+
+    switch (typeFromTag(a.tag)) {
+    case TagType::INVALID:
+    case TagType::BOOL:
+        return true;
+    case TagType::ENUM:
+    case TagType::ENUM_REP:
+    case TagType::UINT:
+    case TagType::UINT_REP:
+        return a.f.integer == b.f.integer;
+    case TagType::ULONG:
+    case TagType::ULONG_REP:
+        return a.f.longInteger == b.f.longInteger;
+    case TagType::DATE:
+        return a.f.dateTime == b.f.dateTime;
+    case TagType::BIGNUM:
+    case TagType::BYTES:
+        if (a.blob.size() != b.blob.size()) return false;
+        return a.blob.size() == 0 || memcmp(&a.blob[0], &b.blob[0], a.blob.size()) == 0;
+    }
+    return false;
+}
+
+void AuthorizationSet::Sort() {
+    std::sort(data_.begin(), data_.end(), keyParamLess);
+}
+
+void AuthorizationSet::Deduplicate() {
+    if (data_.empty()) return;
+
+    Sort();
+    std::vector<KeyParameter> result;
+
+    auto curr = data_.begin();
+    auto prev = curr++;
+    for (; curr != data_.end(); ++prev, ++curr) {
+        if (prev->tag == Tag::INVALID) continue;
+
+        if (!keyParamEqual(*prev, *curr)) {
+            result.emplace_back(std::move(*prev));
+        }
+    }
+    result.emplace_back(std::move(*prev));
+
+    std::swap(data_, result);
+}
+
+void AuthorizationSet::Union(const AuthorizationSet& other) {
+    data_.insert(data_.end(), other.data_.begin(), other.data_.end());
+    Deduplicate();
+}
+
+void AuthorizationSet::Subtract(const AuthorizationSet& other) {
+    Deduplicate();
+
+    auto i = other.begin();
+    while (i != other.end()) {
+        int pos = -1;
+        do {
+            pos = find(i->tag, pos);
+            if (pos != -1 && keyParamEqual(*i, data_[pos])) {
+                data_.erase(data_.begin() + pos);
+                break;
+            }
+        } while (pos != -1);
+        ++i;
+    }
+}
+
+int AuthorizationSet::find(Tag tag, int begin) const {
+    auto iter = data_.begin() + (1 + begin);
+
+    while (iter != data_.end() && iter->tag != tag)
+        ++iter;
+
+    if (iter != data_.end()) return iter - data_.begin();
+    return -1;
+}
+
+bool AuthorizationSet::erase(int index) {
+    auto pos = data_.begin() + index;
+    if (pos != data_.end()) {
+        data_.erase(pos);
+        return true;
+    }
+    return false;
+}
+
+KeyParameter& AuthorizationSet::operator[](int at) {
+    return data_[at];
+}
+
+const KeyParameter& AuthorizationSet::operator[](int at) const {
+    return data_[at];
+}
+
+void AuthorizationSet::Clear() {
+    data_.clear();
+}
+
+size_t AuthorizationSet::GetTagCount(Tag tag) const {
+    size_t count = 0;
+    for (int pos = -1; (pos = find(tag, pos)) != -1;)
+        ++count;
+    return count;
+}
+
+NullOr<const KeyParameter&> AuthorizationSet::GetEntry(Tag tag) const {
+    int pos = find(tag);
+    if (pos == -1) return {};
+    return data_[pos];
+}
+
+/**
+ * Persistent format is:
+ * | 32 bit indirect_size         |
+ * --------------------------------
+ * | indirect_size bytes of data  | this is where the blob data is stored
+ * --------------------------------
+ * | 32 bit element_count         | number of entries
+ * | 32 bit elements_size         | total bytes used by entries (entries have variable length)
+ * --------------------------------
+ * | elementes_size bytes of data | where the elements are stored
+ */
+
+/**
+ * Persistent format of blobs and bignums:
+ * | 32 bit tag             |
+ * | 32 bit blob_length     |
+ * | 32 bit indirect_offset |
+ */
+
+struct OutStreams {
+    std::ostream& indirect;
+    std::ostream& elements;
+};
+
+OutStreams& serializeParamValue(OutStreams& out, const hidl_vec<uint8_t>& blob) {
+    uint32_t buffer;
+
+    // write blob_length
+    auto blob_length = blob.size();
+    if (blob_length > std::numeric_limits<uint32_t>::max()) {
+        out.elements.setstate(std::ios_base::badbit);
+        return out;
+    }
+    buffer = blob_length;
+    out.elements.write(reinterpret_cast<const char*>(&buffer), sizeof(uint32_t));
+
+    // write indirect_offset
+    auto offset = out.indirect.tellp();
+    if (offset < 0 || offset > std::numeric_limits<uint32_t>::max() ||
+        static_cast<uint32_t>((std::numeric_limits<uint32_t>::max() - offset)) <
+            blob_length) {  // overflow check
+        out.elements.setstate(std::ios_base::badbit);
+        return out;
+    }
+    buffer = offset;
+    out.elements.write(reinterpret_cast<const char*>(&buffer), sizeof(uint32_t));
+
+    // write blob to indirect stream
+    if (blob_length) out.indirect.write(reinterpret_cast<const char*>(&blob[0]), blob_length);
+
+    return out;
+}
+
+template <typename T> OutStreams& serializeParamValue(OutStreams& out, const T& value) {
+    out.elements.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    return out;
+}
+
+OutStreams& serialize(TAG_INVALID_t&&, OutStreams& out, const KeyParameter&) {
+    // skip invalid entries.
+    return out;
+}
+template <typename T> OutStreams& serialize(T ttag, OutStreams& out, const KeyParameter& param) {
+    out.elements.write(reinterpret_cast<const char*>(&param.tag), sizeof(int32_t));
+    return serializeParamValue(out, accessTagValue(ttag, param));
+}
+
+template <typename... T> struct choose_serializer;
+template <typename... Tags> struct choose_serializer<MetaList<Tags...>> {
+    static OutStreams& serialize(OutStreams& out, const KeyParameter& param) {
+        return choose_serializer<Tags...>::serialize(out, param);
+    }
+};
+template <> struct choose_serializer<> {
+    static OutStreams& serialize(OutStreams& out, const KeyParameter&) { return out; }
+};
+template <TagType tag_type, Tag tag, typename... Tail>
+struct choose_serializer<TypedTag<tag_type, tag>, Tail...> {
+    static OutStreams& serialize(OutStreams& out, const KeyParameter& param) {
+        if (param.tag == tag) {
+            return V3_0::serialize(TypedTag<tag_type, tag>(), out, param);
+        } else {
+            return choose_serializer<Tail...>::serialize(out, param);
+        }
+    }
+};
+
+OutStreams& serialize(OutStreams& out, const KeyParameter& param) {
+    return choose_serializer<all_tags_t>::serialize(out, param);
+}
+
+std::ostream& serialize(std::ostream& out, const std::vector<KeyParameter>& params) {
+    std::stringstream indirect;
+    std::stringstream elements;
+    OutStreams streams = {indirect, elements};
+    for (const auto& param : params) {
+        serialize(streams, param);
+    }
+    if (indirect.bad() || elements.bad()) {
+        out.setstate(std::ios_base::badbit);
+        return out;
+    }
+    auto pos = indirect.tellp();
+    if (pos < 0 || pos > std::numeric_limits<uint32_t>::max()) {
+        out.setstate(std::ios_base::badbit);
+        return out;
+    }
+    uint32_t indirect_size = pos;
+    pos = elements.tellp();
+    if (pos < 0 || pos > std::numeric_limits<uint32_t>::max()) {
+        out.setstate(std::ios_base::badbit);
+        return out;
+    }
+    uint32_t elements_size = pos;
+    uint32_t element_count = params.size();
+
+    out.write(reinterpret_cast<const char*>(&indirect_size), sizeof(uint32_t));
+
+    pos = out.tellp();
+    if (indirect_size) out << indirect.rdbuf();
+    assert(out.tellp() - pos == indirect_size);
+
+    out.write(reinterpret_cast<const char*>(&element_count), sizeof(uint32_t));
+    out.write(reinterpret_cast<const char*>(&elements_size), sizeof(uint32_t));
+
+    pos = out.tellp();
+    if (elements_size) out << elements.rdbuf();
+    assert(out.tellp() - pos == elements_size);
+
+    return out;
+}
+
+struct InStreams {
+    std::istream& indirect;
+    std::istream& elements;
+};
+
+InStreams& deserializeParamValue(InStreams& in, hidl_vec<uint8_t>* blob) {
+    uint32_t blob_length = 0;
+    uint32_t offset = 0;
+    in.elements.read(reinterpret_cast<char*>(&blob_length), sizeof(uint32_t));
+    blob->resize(blob_length);
+    in.elements.read(reinterpret_cast<char*>(&offset), sizeof(uint32_t));
+    in.indirect.seekg(offset);
+    in.indirect.read(reinterpret_cast<char*>(&(*blob)[0]), blob->size());
+    return in;
+}
+
+template <typename T> InStreams& deserializeParamValue(InStreams& in, T* value) {
+    in.elements.read(reinterpret_cast<char*>(value), sizeof(T));
+    return in;
+}
+
+InStreams& deserialize(TAG_INVALID_t&&, InStreams& in, KeyParameter*) {
+    // there should be no invalid KeyParamaters but if handle them as zero sized.
+    return in;
+}
+
+template <typename T> InStreams& deserialize(T&& ttag, InStreams& in, KeyParameter* param) {
+    return deserializeParamValue(in, &accessTagValue(ttag, *param));
+}
+
+template <typename... T> struct choose_deserializer;
+template <typename... Tags> struct choose_deserializer<MetaList<Tags...>> {
+    static InStreams& deserialize(InStreams& in, KeyParameter* param) {
+        return choose_deserializer<Tags...>::deserialize(in, param);
+    }
+};
+template <> struct choose_deserializer<> {
+    static InStreams& deserialize(InStreams& in, KeyParameter*) {
+        // encountered an unknown tag -> fail parsing
+        in.elements.setstate(std::ios_base::badbit);
+        return in;
+    }
+};
+template <TagType tag_type, Tag tag, typename... Tail>
+struct choose_deserializer<TypedTag<tag_type, tag>, Tail...> {
+    static InStreams& deserialize(InStreams& in, KeyParameter* param) {
+        if (param->tag == tag) {
+            return V3_0::deserialize(TypedTag<tag_type, tag>(), in, param);
+        } else {
+            return choose_deserializer<Tail...>::deserialize(in, param);
+        }
+    }
+};
+
+InStreams& deserialize(InStreams& in, KeyParameter* param) {
+    in.elements.read(reinterpret_cast<char*>(&param->tag), sizeof(Tag));
+    return choose_deserializer<all_tags_t>::deserialize(in, param);
+}
+
+std::istream& deserialize(std::istream& in, std::vector<KeyParameter>* params) {
+    uint32_t indirect_size = 0;
+    in.read(reinterpret_cast<char*>(&indirect_size), sizeof(uint32_t));
+    std::string indirect_buffer(indirect_size, '\0');
+    if (indirect_buffer.size() != indirect_size) {
+        in.setstate(std::ios_base::badbit);
+        return in;
+    }
+    in.read(&indirect_buffer[0], indirect_buffer.size());
+
+    uint32_t element_count = 0;
+    in.read(reinterpret_cast<char*>(&element_count), sizeof(uint32_t));
+    uint32_t elements_size = 0;
+    in.read(reinterpret_cast<char*>(&elements_size), sizeof(uint32_t));
+
+    std::string elements_buffer(elements_size, '\0');
+    if (elements_buffer.size() != elements_size) {
+        in.setstate(std::ios_base::badbit);
+        return in;
+    }
+    in.read(&elements_buffer[0], elements_buffer.size());
+
+    if (in.bad()) return in;
+
+    // TODO write one-shot stream buffer to avoid copying here
+    std::stringstream indirect(indirect_buffer);
+    std::stringstream elements(elements_buffer);
+    InStreams streams = {indirect, elements};
+
+    params->resize(element_count);
+
+    for (uint32_t i = 0; i < element_count; ++i) {
+        deserialize(streams, &(*params)[i]);
+    }
+    return in;
+}
+
+void AuthorizationSet::Serialize(std::ostream* out) const {
+    serialize(*out, data_);
+}
+
+void AuthorizationSet::Deserialize(std::istream* in) {
+    deserialize(*in, &data_);
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/authorization_set.h
+++ b/test/functional/authorization_set.h
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_AUTHORIZATION_SET_H_
+#define HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_AUTHORIZATION_SET_H_
+
+#include "keymaster_tags.h"
+
+#include <utility>
+#include <vector>
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+class AuthorizationSetBuilder;
+
+/**
+ * An ordered collection of KeyParameters. It provides memory ownership and some convenient
+ * functionality for sorting, deduplicating, joining, and subtracting sets of KeyParameters.
+ * For serialization, wrap the backing store of this structure in a hidl_vec<KeyParameter>.
+ */
+class AuthorizationSet {
+  public:
+    typedef KeyParameter value_type;
+
+    /**
+     * Construct an empty, dynamically-allocated, growable AuthorizationSet.
+     */
+    AuthorizationSet(){};
+
+    // Copy constructor.
+    AuthorizationSet(const AuthorizationSet& other) : data_(other.data_) {}
+
+    // Move constructor.
+    AuthorizationSet(AuthorizationSet&& other) : data_(std::move(other.data_)) {}
+
+    // Constructor from hidl_vec<KeyParameter>
+    AuthorizationSet(const hidl_vec<KeyParameter>& other) { *this = other; }
+
+    // Copy assignment.
+    AuthorizationSet& operator=(const AuthorizationSet& other) {
+        data_ = other.data_;
+        return *this;
+    }
+
+    // Move assignment.
+    AuthorizationSet& operator=(AuthorizationSet&& other) {
+        data_ = std::move(other.data_);
+        return *this;
+    }
+
+    AuthorizationSet& operator=(const hidl_vec<KeyParameter>& other) {
+        if (other.size() > 0) {
+            data_.resize(other.size());
+            for (size_t i = 0; i < data_.size(); ++i) {
+                /* This makes a deep copy even of embedded blobs.
+                 * See assignment operator/copy constructor of hidl_vec.*/
+                data_[i] = other[i];
+            }
+        }
+        return *this;
+    }
+
+    /**
+     * Clear existing authorization set data
+     */
+    void Clear();
+
+    ~AuthorizationSet() = default;
+
+    /**
+     * Returns the size of the set.
+     */
+    size_t size() const { return data_.size(); }
+
+    /**
+     * Returns true if the set is empty.
+     */
+    bool empty() const { return size() == 0; }
+
+    /**
+     * Returns the data in the set, directly. Be careful with this.
+     */
+    const KeyParameter* data() const { return data_.data(); }
+
+    /**
+     * Sorts the set
+     */
+    void Sort();
+
+    /**
+     * Sorts the set and removes duplicates (inadvertently duplicating tags is easy to do with the
+     * AuthorizationSetBuilder).
+     */
+    void Deduplicate();
+
+    /**
+     * Adds all elements from \p set that are not already present in this AuthorizationSet.  As a
+     * side-effect, if \p set is not null this AuthorizationSet will end up sorted.
+     */
+    void Union(const AuthorizationSet& set);
+
+    /**
+     * Removes all elements in \p set from this AuthorizationSet.
+     */
+    void Subtract(const AuthorizationSet& set);
+
+    /**
+     * Returns the offset of the next entry that matches \p tag, starting from the element after \p
+     * begin.  If not found, returns -1.
+     */
+    int find(Tag tag, int begin = -1) const;
+
+    /**
+     * Removes the entry at the specified index. Returns true if successful, false if the index was
+     * out of bounds.
+     */
+    bool erase(int index);
+
+    /**
+     * Returns iterator (pointer) to beginning of elems array, to enable STL-style iteration
+     */
+    std::vector<KeyParameter>::const_iterator begin() const { return data_.begin(); }
+
+    /**
+     * Returns iterator (pointer) one past end of elems array, to enable STL-style iteration
+     */
+    std::vector<KeyParameter>::const_iterator end() const { return data_.end(); }
+
+    /**
+     * Returns the nth element of the set.
+     * Like for std::vector::operator[] there is no range check performed. Use of out of range
+     * indices is undefined.
+     */
+    KeyParameter& operator[](int n);
+
+    /**
+     * Returns the nth element of the set.
+     * Like for std::vector::operator[] there is no range check performed. Use of out of range
+     * indices is undefined.
+     */
+    const KeyParameter& operator[](int n) const;
+
+    /**
+     * Returns true if the set contains at least one instance of \p tag
+     */
+    bool Contains(Tag tag) const { return find(tag) != -1; }
+
+    template <typename T> bool Contains(T tag) const { return find(tag) != -1; }
+
+    template <TagType tag_type, Tag tag, typename ValueT>
+    bool Contains(TypedTag<tag_type, tag> ttag, const ValueT& value) const {
+        for (const auto& param : data_) {
+            auto entry = authorizationValue(ttag, param);
+            if (entry.isOk() && static_cast<ValueT>(entry.value()) == value) return true;
+        }
+        return false;
+    }
+    /**
+     * Returns the number of \p tag entries.
+     */
+    size_t GetTagCount(Tag tag) const;
+
+    template <typename T>
+    inline NullOr<const typename TypedTag2ValueType<T>::type&> GetTagValue(T tag) const {
+        auto entry = GetEntry(tag);
+        if (entry.isOk()) return authorizationValue(tag, entry.value());
+        return {};
+    }
+
+    void push_back(const KeyParameter& param) { data_.push_back(param); }
+    void push_back(KeyParameter&& param) { data_.push_back(std::move(param)); }
+
+    void push_back(const AuthorizationSet& set) {
+        for (auto& entry : set) {
+            push_back(entry);
+        }
+    }
+
+    void push_back(AuthorizationSet&& set) {
+        move(set.begin(), set.end());
+        set.Clear();
+    }
+
+    template <Tag tag>
+    void push_back(TypedTag<TagType::BYTES, tag> ttag, const uint8_t* data, size_t data_length) {
+        hidl_vec<uint8_t> new_blob;
+        new_blob.setToExternal(const_cast<uint8_t*>(data), data_length);
+        push_back(ttag, std::move(new_blob));
+    }
+
+    /**
+     * Append the tag and enumerated value to the set.
+     * "val" may be exactly one parameter unless a boolean parameter is added.
+     * In this case "val" is omitted. This condition is checked at compile time by Authorization()
+     */
+    template <typename TypedTagT, typename... Value> void push_back(TypedTagT tag, Value&&... val) {
+        push_back(Authorization(tag, std::forward<Value>(val)...));
+    }
+
+    template <typename Iterator> void push_back(Iterator begin, Iterator end) {
+        while (begin != end) {
+            push_back(*begin);
+            ++begin;
+        }
+    }
+
+    template <typename Iterator> void move(Iterator begin, Iterator end) {
+        std::move(begin, end, std::back_inserter(data_));
+    }
+
+    hidl_vec<KeyParameter> hidl_data() const {
+        hidl_vec<KeyParameter> result;
+        result.setToExternal(const_cast<KeyParameter*>(data()), size());
+        return result;
+    }
+
+    void Serialize(std::ostream* out) const;
+    void Deserialize(std::istream* in);
+
+  private:
+    NullOr<const KeyParameter&> GetEntry(Tag tag) const;
+
+    std::vector<KeyParameter> data_;
+};
+
+class AuthorizationSetBuilder : public AuthorizationSet {
+  public:
+    template <typename TagType, typename... ValueType>
+    AuthorizationSetBuilder& Authorization(TagType ttag, ValueType&&... value) {
+        push_back(ttag, std::forward<ValueType>(value)...);
+        return *this;
+    }
+
+    template <Tag tag>
+    AuthorizationSetBuilder& Authorization(TypedTag<TagType::BYTES, tag> ttag, const uint8_t* data,
+                                           size_t data_length) {
+        hidl_vec<uint8_t> new_blob;
+        new_blob.setToExternal(const_cast<uint8_t*>(data), data_length);
+        push_back(ttag, std::move(new_blob));
+        return *this;
+    }
+
+    template <Tag tag>
+    AuthorizationSetBuilder& Authorization(TypedTag<TagType::BYTES, tag> ttag, const char* data,
+                                           size_t data_length) {
+        return Authorization(ttag, reinterpret_cast<const uint8_t*>(data), data_length);
+    }
+
+    AuthorizationSetBuilder& Authorizations(AuthorizationSet&& set);
+    AuthorizationSetBuilder& Authorizations(const AuthorizationSet& set);
+
+    AuthorizationSetBuilder& RsaKey(uint32_t key_size, uint64_t public_exponent);
+    AuthorizationSetBuilder& EcdsaKey(uint32_t key_size);
+    AuthorizationSetBuilder& EcdsaKey(EcCurve curve);
+    AuthorizationSetBuilder& AesKey(uint32_t key_size);
+    AuthorizationSetBuilder& HmacKey(uint32_t key_size);
+
+    AuthorizationSetBuilder& RsaSigningKey(uint32_t key_size, uint64_t public_exponent);
+    AuthorizationSetBuilder& RsaEncryptionKey(uint32_t key_size, uint64_t public_exponent);
+    AuthorizationSetBuilder& EcdsaSigningKey(uint32_t key_size);
+    AuthorizationSetBuilder& EcdsaSigningKey(EcCurve curve);
+    AuthorizationSetBuilder& AesEncryptionKey(uint32_t key_size);
+
+    AuthorizationSetBuilder& SigningKey();
+    AuthorizationSetBuilder& EncryptionKey();
+    AuthorizationSetBuilder& NoDigestOrPadding();
+    AuthorizationSetBuilder& EcbMode();
+
+    AuthorizationSetBuilder& BlockMode(std::initializer_list<BlockMode> block_modes);
+    AuthorizationSetBuilder& Digest(std::initializer_list<Digest> digests);
+    AuthorizationSetBuilder& Padding(std::initializer_list<PaddingMode> padding_modes);
+
+    // The following forwarding templates enable BlockMode,Digest and Padding to be called with a
+    // variable number of arguments; no need to wrap them in braces to make them an initalizer_list.
+    template <typename... T> AuthorizationSetBuilder& BlockMode(T&&... a) {
+        return BlockMode({std::forward<T>(a)...});
+    }
+    template <typename... T> AuthorizationSetBuilder& Digest(T&&... a) {
+        return Digest({std::forward<T>(a)...});
+    }
+    template <typename... T> AuthorizationSetBuilder& Padding(T&&... a) {
+        return Padding({std::forward<T>(a)...});
+    }
+};
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::Authorizations(AuthorizationSet&& set) {
+    move(set.begin(), set.end());
+    set.Clear();
+    return *this;
+}
+
+inline AuthorizationSetBuilder&
+AuthorizationSetBuilder::Authorizations(const AuthorizationSet& set) {
+    push_back(set.begin(), set.end());
+    return *this;
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::RsaKey(uint32_t key_size,
+                                                                uint64_t public_exponent) {
+    Authorization(TAG_ALGORITHM, Algorithm::RSA);
+    Authorization(TAG_KEY_SIZE, key_size);
+    Authorization(TAG_RSA_PUBLIC_EXPONENT, public_exponent);
+    return *this;
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EcdsaKey(uint32_t key_size) {
+    Authorization(TAG_ALGORITHM, Algorithm::EC);
+    Authorization(TAG_KEY_SIZE, key_size);
+    return *this;
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EcdsaKey(EcCurve curve) {
+    Authorization(TAG_ALGORITHM, Algorithm::EC);
+    Authorization(TAG_EC_CURVE, curve);
+    return *this;
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::AesKey(uint32_t key_size) {
+    Authorization(TAG_ALGORITHM, Algorithm::AES);
+    return Authorization(TAG_KEY_SIZE, key_size);
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::HmacKey(uint32_t key_size) {
+    Authorization(TAG_ALGORITHM, Algorithm::HMAC);
+    Authorization(TAG_KEY_SIZE, key_size);
+    return SigningKey();
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::RsaSigningKey(uint32_t key_size,
+                                                                       uint64_t public_exponent) {
+    RsaKey(key_size, public_exponent);
+    return SigningKey();
+}
+
+inline AuthorizationSetBuilder&
+AuthorizationSetBuilder::RsaEncryptionKey(uint32_t key_size, uint64_t public_exponent) {
+    RsaKey(key_size, public_exponent);
+    return EncryptionKey();
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EcdsaSigningKey(uint32_t key_size) {
+    EcdsaKey(key_size);
+    return SigningKey();
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EcdsaSigningKey(EcCurve curve) {
+    EcdsaKey(curve);
+    return SigningKey();
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::AesEncryptionKey(uint32_t key_size) {
+    AesKey(key_size);
+    return EncryptionKey();
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::SigningKey() {
+    Authorization(TAG_PURPOSE, KeyPurpose::SIGN);
+    return Authorization(TAG_PURPOSE, KeyPurpose::VERIFY);
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EncryptionKey() {
+    Authorization(TAG_PURPOSE, KeyPurpose::ENCRYPT);
+    return Authorization(TAG_PURPOSE, KeyPurpose::DECRYPT);
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::NoDigestOrPadding() {
+    Authorization(TAG_DIGEST, Digest::NONE);
+    return Authorization(TAG_PADDING, PaddingMode::NONE);
+}
+
+inline AuthorizationSetBuilder& AuthorizationSetBuilder::EcbMode() {
+    return BlockMode(BlockMode::ECB);
+}
+
+inline AuthorizationSetBuilder&
+AuthorizationSetBuilder::BlockMode(std::initializer_list<V3_0::BlockMode> block_modes) {
+    for (auto block_mode : block_modes) {
+        Authorization(TAG_BLOCK_MODE, block_mode);
+    }
+    return *this;
+}
+
+inline AuthorizationSetBuilder&
+AuthorizationSetBuilder::Digest(std::initializer_list<V3_0::Digest> digests) {
+    for (auto digest : digests) {
+        Authorization(TAG_DIGEST, digest);
+    }
+    return *this;
+}
+
+inline AuthorizationSetBuilder&
+AuthorizationSetBuilder::Padding(std::initializer_list<V3_0::PaddingMode> padding_modes) {
+    for (auto padding : padding_modes) {
+        Authorization(TAG_PADDING, padding);
+    }
+    return *this;
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android
+
+#endif  // HARDWARE_INTERFACES_KEYMASTER_30_VTS_FUNCTIONAL_AUTHORIZATION_SET_H_

--- a/test/functional/key_param_output.cpp
+++ b/test/functional/key_param_output.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "key_param_output.h"
+
+#include <iomanip>
+
+namespace android {
+namespace hardware {
+
+namespace keymaster {
+namespace V3_0 {
+
+::std::ostream& operator<<(::std::ostream& os, const hidl_vec<KeyParameter>& set) {
+    if (set.size() == 0) {
+        os << "(Empty)" << ::std::endl;
+    } else {
+        os << "\n";
+        for (size_t i = 0; i < set.size(); ++i)
+            os << set[i] << ::std::endl;
+    }
+    return os;
+}
+
+::std::ostream& operator<<(::std::ostream& os, ErrorCode value) {
+    return os << (int)value;
+}
+
+::std::ostream& operator<<(::std::ostream& os, Digest value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, Algorithm value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, BlockMode value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, PaddingMode value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, KeyOrigin value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, KeyPurpose value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, EcCurve value) {
+    return os << stringify(value);
+}
+
+::std::ostream& operator<<(::std::ostream& os, const KeyParameter& param) {
+    os << stringifyTag(param.tag) << ": ";
+    switch (typeFromTag(param.tag)) {
+    case TagType::INVALID:
+        return os << " Invalid";
+    case TagType::UINT_REP:
+    case TagType::UINT:
+        return os << param.f.integer;
+    case TagType::ENUM_REP:
+    case TagType::ENUM:
+        switch (param.tag) {
+        case Tag::ALGORITHM:
+            return os << param.f.algorithm;
+        case Tag::BLOCK_MODE:
+            return os << param.f.blockMode;
+        case Tag::PADDING:
+            return os << param.f.paddingMode;
+        case Tag::DIGEST:
+            return os << param.f.digest;
+        case Tag::EC_CURVE:
+            return os << (int)param.f.ecCurve;
+        case Tag::ORIGIN:
+            return os << param.f.origin;
+        case Tag::BLOB_USAGE_REQUIREMENTS:
+            return os << (int)param.f.keyBlobUsageRequirements;
+        case Tag::PURPOSE:
+            return os << param.f.purpose;
+        default:
+            return os << " UNKNOWN ENUM " << param.f.integer;
+        }
+    case TagType::ULONG_REP:
+    case TagType::ULONG:
+        return os << param.f.longInteger;
+    case TagType::DATE:
+        return os << param.f.dateTime;
+    case TagType::BOOL:
+        return os << "true";
+    case TagType::BIGNUM:
+        os << " Bignum: ";
+        for (size_t i = 0; i < param.blob.size(); ++i) {
+            os << ::std::hex << ::std::setw(2) << static_cast<int>(param.blob[i]) << ::std::dec;
+        }
+        return os;
+    case TagType::BYTES:
+        os << " Bytes: ";
+        for (size_t i = 0; i < param.blob.size(); ++i) {
+            os << ::std::hex << ::std::setw(2) << static_cast<int>(param.blob[i]) << ::std::dec;
+        }
+        return os;
+    }
+    return os << "UNKNOWN TAG TYPE!";
+}
+
+::std::ostream& operator<<(::std::ostream& os, const KeyCharacteristics& chars) {
+    return os << "SW: " << chars.softwareEnforced << ::std::endl
+              << "TEE: " << chars.teeEnforced << ::std::endl;
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/key_param_output.h
+++ b/test/functional/key_param_output.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <android/hardware/keymaster/3.0/types.h>
+
+#include "keymaster_tags.h"
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+template <typename ValueT>
+::std::ostream& operator<<(::std::ostream& os, const NullOr<ValueT>& value) {
+    if (!value.isOk()) {
+        os << "(value not present)";
+    } else {
+        os << value.value();
+    }
+    return os;
+}
+
+::std::ostream& operator<<(::std::ostream& os, const hidl_vec<KeyParameter>& set);
+::std::ostream& operator<<(::std::ostream& os, BlockMode value);
+::std::ostream& operator<<(::std::ostream& os, Digest value);
+::std::ostream& operator<<(::std::ostream& os, EcCurve value);
+::std::ostream& operator<<(::std::ostream& os, ErrorCode value);
+::std::ostream& operator<<(::std::ostream& os, PaddingMode value);
+::std::ostream& operator<<(::std::ostream& os, const KeyCharacteristics& value);
+::std::ostream& operator<<(::std::ostream& os, const KeyParameter& value);
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/keymaster_hidl_hal_test.cpp
+++ b/test/functional/keymaster_hidl_hal_test.cpp
@@ -1,0 +1,622 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "keymaster_hidl_hal_test"
+#include <cutils/log.h>
+
+#include <iostream>
+#include <unistd.h>
+
+#include <openssl/evp.h>
+#include <openssl/mem.h>
+#include <openssl/x509.h>
+
+#include <android/hardware/keymaster/3.0/IKeymasterDevice.h>
+#include <android/hardware/keymaster/3.0/types.h>
+
+#include <cutils/properties.h>
+
+#include <keymaster/keymaster_configuration.h>
+
+#include "authorization_set.h"
+#include "key_param_output.h"
+
+#include <VtsHalHidlTargetTestBase.h>
+#include <VtsHalHidlTargetTestEnvBase.h>
+
+#include "attestation_record.h"
+#include "openssl_utils.h"
+
+#define KM_MAX_USE_TIMERS 32U
+
+using ::android::sp;
+using ::std::string;
+
+static bool arm_deleteAllKeys = false;
+static bool dump_Attestations = false;
+
+namespace android {
+namespace hardware {
+
+template <typename T> bool operator==(const hidl_vec<T>& a, const hidl_vec<T>& b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+namespace keymaster {
+namespace V3_0 {
+
+bool operator==(const KeyParameter& a, const KeyParameter& b) {
+    if (a.tag != b.tag) {
+        return false;
+    }
+
+    switch (a.tag) {
+
+    /* Boolean tags */
+    case Tag::INVALID:
+    case Tag::CALLER_NONCE:
+    case Tag::INCLUDE_UNIQUE_ID:
+    case Tag::ECIES_SINGLE_HASH_MODE:
+    case Tag::BOOTLOADER_ONLY:
+    case Tag::NO_AUTH_REQUIRED:
+    case Tag::ALLOW_WHILE_ON_BODY:
+    case Tag::EXPORTABLE:
+    case Tag::ALL_APPLICATIONS:
+    case Tag::ROLLBACK_RESISTANT:
+    case Tag::RESET_SINCE_ID_ROTATION:
+        return true;
+
+    /* Integer tags */
+    case Tag::KEY_SIZE:
+    case Tag::MIN_MAC_LENGTH:
+    case Tag::MIN_SECONDS_BETWEEN_OPS:
+    case Tag::MAX_USES_PER_BOOT:
+    case Tag::ALL_USERS:
+    case Tag::USER_ID:
+    case Tag::OS_VERSION:
+    case Tag::OS_PATCHLEVEL:
+    case Tag::MAC_LENGTH:
+    case Tag::AUTH_TIMEOUT:
+        return a.f.integer == b.f.integer;
+
+    /* Long integer tags */
+    case Tag::RSA_PUBLIC_EXPONENT:
+    case Tag::USER_SECURE_ID:
+        return a.f.longInteger == b.f.longInteger;
+
+    /* Date-time tags */
+    case Tag::ACTIVE_DATETIME:
+    case Tag::ORIGINATION_EXPIRE_DATETIME:
+    case Tag::USAGE_EXPIRE_DATETIME:
+    case Tag::CREATION_DATETIME:
+        return a.f.dateTime == b.f.dateTime;
+
+    /* Bytes tags */
+    case Tag::APPLICATION_ID:
+    case Tag::APPLICATION_DATA:
+    case Tag::ROOT_OF_TRUST:
+    case Tag::UNIQUE_ID:
+    case Tag::ATTESTATION_CHALLENGE:
+    case Tag::ATTESTATION_APPLICATION_ID:
+    case Tag::ATTESTATION_ID_BRAND:
+    case Tag::ATTESTATION_ID_DEVICE:
+    case Tag::ATTESTATION_ID_PRODUCT:
+    case Tag::ATTESTATION_ID_SERIAL:
+    case Tag::ATTESTATION_ID_IMEI:
+    case Tag::ATTESTATION_ID_MEID:
+    case Tag::ATTESTATION_ID_MANUFACTURER:
+    case Tag::ATTESTATION_ID_MODEL:
+    case Tag::ASSOCIATED_DATA:
+    case Tag::NONCE:
+    case Tag::AUTH_TOKEN:
+        return a.blob == b.blob;
+
+    /* Enum tags */
+    case Tag::PURPOSE:
+        return a.f.purpose == b.f.purpose;
+    case Tag::ALGORITHM:
+        return a.f.algorithm == b.f.algorithm;
+    case Tag::BLOCK_MODE:
+        return a.f.blockMode == b.f.blockMode;
+    case Tag::DIGEST:
+        return a.f.digest == b.f.digest;
+    case Tag::PADDING:
+        return a.f.paddingMode == b.f.paddingMode;
+    case Tag::EC_CURVE:
+        return a.f.ecCurve == b.f.ecCurve;
+    case Tag::BLOB_USAGE_REQUIREMENTS:
+        return a.f.keyBlobUsageRequirements == b.f.keyBlobUsageRequirements;
+    case Tag::USER_AUTH_TYPE:
+        return a.f.integer == b.f.integer;
+    case Tag::ORIGIN:
+        return a.f.origin == b.f.origin;
+
+    /* Unsupported tags */
+    case Tag::KDF:
+        return false;
+    }
+}
+
+bool operator==(const AuthorizationSet& a, const AuthorizationSet& b) {
+    return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+
+bool operator==(const KeyCharacteristics& a, const KeyCharacteristics& b) {
+    // This isn't very efficient. Oh, well.
+    AuthorizationSet a_sw(a.softwareEnforced);
+    AuthorizationSet b_sw(b.softwareEnforced);
+    AuthorizationSet a_tee(b.teeEnforced);
+    AuthorizationSet b_tee(b.teeEnforced);
+
+    a_sw.Sort();
+    b_sw.Sort();
+    a_tee.Sort();
+    b_tee.Sort();
+
+    return a_sw == b_sw && a_tee == b_sw;
+}
+
+::std::ostream& operator<<(::std::ostream& os, const AuthorizationSet& set) {
+    if (set.size() == 0)
+        os << "(Empty)" << ::std::endl;
+    else {
+        os << "\n";
+        for (size_t i = 0; i < set.size(); ++i)
+            os << set[i] << ::std::endl;
+    }
+    return os;
+}
+
+namespace test {
+namespace {
+
+template <TagType tag_type, Tag tag, typename ValueT>
+bool contains(hidl_vec<KeyParameter>& set, TypedTag<tag_type, tag> ttag, ValueT expected_value) {
+    size_t count = std::count_if(set.begin(), set.end(), [&](const KeyParameter& param) {
+        return param.tag == tag && accessTagValue(ttag, param) == expected_value;
+    });
+    return count == 1;
+}
+
+template <TagType tag_type, Tag tag>
+bool contains(hidl_vec<KeyParameter>& set, TypedTag<tag_type, tag>) {
+    size_t count = std::count_if(set.begin(), set.end(),
+                                 [&](const KeyParameter& param) { return param.tag == tag; });
+    return count > 0;
+}
+
+constexpr char hex_value[256] = {0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 1,  2,  3,  4,  5,  6,  7, 8, 9, 0, 0, 0, 0, 0, 0,  // '0'..'9'
+                                 0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 'A'..'F'
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 'a'..'f'
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,  //
+                                 0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+string hex2str(string a) {
+    string b;
+    size_t num = a.size() / 2;
+    b.resize(num);
+    for (size_t i = 0; i < num; i++) {
+        b[i] = (hex_value[a[i * 2] & 0xFF] << 4) + (hex_value[a[i * 2 + 1] & 0xFF]);
+    }
+    return b;
+}
+
+string rsa_key = hex2str(
+    "30820275020100300d06092a864886f70d01010105000482025f3082025b"
+    "02010002818100c6095409047d8634812d5a218176e45c41d60a75b13901"
+    "f234226cffe776521c5a77b9e389417b71c0b6a44d13afe4e4a2805d46c9"
+    "da2935adb1ff0c1f24ea06e62b20d776430a4d435157233c6f916783c30e"
+    "310fcbd89b85c2d56771169785ac12bca244abda72bfb19fc44d27c81e1d"
+    "92de284f4061edfd99280745ea6d2502030100010281801be0f04d9cae37"
+    "18691f035338308e91564b55899ffb5084d2460e6630257e05b3ceab0297"
+    "2dfabcd6ce5f6ee2589eb67911ed0fac16e43a444b8c861e544a05933657"
+    "72f8baf6b22fc9e3c5f1024b063ac080a7b2234cf8aee8f6c47bbf4fd3ac"
+    "e7240290bef16c0b3f7f3cdd64ce3ab5912cf6e32f39ab188358afcccd80"
+    "81024100e4b49ef50f765d3b24dde01aceaaf130f2c76670a91a61ae08af"
+    "497b4a82be6dee8fcdd5e3f7ba1cfb1f0c926b88f88c92bfab137fba2285"
+    "227b83c342ff7c55024100ddabb5839c4c7f6bf3d4183231f005b31aa58a"
+    "ffdda5c79e4cce217f6bc930dbe563d480706c24e9ebfcab28a6cdefd324"
+    "b77e1bf7251b709092c24ff501fd91024023d4340eda3445d8cd26c14411"
+    "da6fdca63c1ccd4b80a98ad52b78cc8ad8beb2842c1d280405bc2f6c1bea"
+    "214a1d742ab996b35b63a82a5e470fa88dbf823cdd02401b7b57449ad30d"
+    "1518249a5f56bb98294d4b6ac12ffc86940497a5a5837a6cf946262b4945"
+    "26d328c11e1126380fde04c24f916dec250892db09a6d77cdba351024077"
+    "62cd8f4d050da56bd591adb515d24d7ccd32cca0d05f866d583514bd7324"
+    "d5f33645e8ed8b4a1cb3cc4a1d67987399f2a09f5b3fb68c88d5e5d90ac3"
+    "3492d6");
+
+string ec_256_key = hex2str(
+    "308187020100301306072a8648ce3d020106082a8648ce3d030107046d30"
+    "6b0201010420737c2ecd7b8d1940bf2930aa9b4ed3ff941eed09366bc032"
+    "99986481f3a4d859a14403420004bf85d7720d07c25461683bc648b4778a"
+    "9a14dd8a024e3bdd8c7ddd9ab2b528bbc7aa1b51f14ebbbb0bd0ce21bcc4"
+    "1c6eb00083cf3376d11fd44949e0b2183bfe");
+
+string ec_521_key = hex2str(
+    "3081EE020100301006072A8648CE3D020106052B810400230481D63081D3"
+    "02010104420011458C586DB5DAA92AFAB03F4FE46AA9D9C3CE9A9B7A006A"
+    "8384BEC4C78E8E9D18D7D08B5BCFA0E53C75B064AD51C449BAE0258D54B9"
+    "4B1E885DED08ED4FB25CE9A1818903818600040149EC11C6DF0FA122C6A9"
+    "AFD9754A4FA9513A627CA329E349535A5629875A8ADFBE27DCB932C05198"
+    "6377108D054C28C6F39B6F2C9AF81802F9F326B842FF2E5F3C00AB7635CF"
+    "B36157FC0882D574A10D839C1A0C049DC5E0D775E2EE50671A208431BB45"
+    "E78E70BEFE930DB34818EE4D5C26259F5C6B8E28A652950F9F88D7B4B2C9"
+    "D9");
+
+class HidlBuf : public hidl_vec<uint8_t> {
+    typedef hidl_vec<uint8_t> super;
+
+  public:
+    HidlBuf() {}
+    HidlBuf(const super& other) : super(other) {}
+    HidlBuf(super&& other) : super(std::move(other)) {}
+    explicit HidlBuf(const std::string& other) : HidlBuf() { *this = other; }
+
+    HidlBuf& operator=(const super& other) {
+        super::operator=(other);
+        return *this;
+    }
+
+    HidlBuf& operator=(super&& other) {
+        super::operator=(std::move(other));
+        return *this;
+    }
+
+    HidlBuf& operator=(const string& other) {
+        resize(other.size());
+        for (size_t i = 0; i < other.size(); ++i) {
+            (*this)[i] = static_cast<uint8_t>(other[i]);
+        }
+        return *this;
+    }
+
+    string to_string() const { return string(reinterpret_cast<const char*>(data()), size()); }
+};
+
+}  // namespace
+
+// Test environment for Keymaster HIDL HAL.
+class KeymasterHidlEnvironment : public ::testing::VtsHalHidlTargetTestEnvBase {
+   public:
+    // get the test environment singleton
+    static KeymasterHidlEnvironment* Instance() {
+        static KeymasterHidlEnvironment* instance = new KeymasterHidlEnvironment;
+        return instance;
+    }
+
+    virtual void registerTestServices() override { registerTestService<IKeymasterDevice>(); }
+   private:
+    KeymasterHidlEnvironment() {}
+};
+
+class KeymasterTest : public ::testing::VtsHalHidlTargetTestBase {
+  public:
+
+    void TearDown() override {
+    }
+
+    // SetUpTestCase runs only once per test case, not once per test.
+    static void SetUpTestCase() {
+        keymaster_ = ::testing::VtsHalHidlTargetTestBase::getService<IKeymasterDevice>(
+            KeymasterHidlEnvironment::Instance()->getServiceName<IKeymasterDevice>());
+        ASSERT_NE(keymaster_, nullptr);
+
+        ASSERT_TRUE(
+            keymaster_
+                ->getHardwareFeatures([&](bool isSecure, bool supportsEc, bool supportsSymmetric,
+                                          bool supportsAttestation, bool supportsAllDigests,
+                                          const hidl_string& name, const hidl_string& author) {
+                    //TODO: Add some initial check
+            (void)(isSecure);
+            (void)(supportsEc);
+            (void)(supportsSymmetric);
+            (void)(supportsAttestation);
+            (void)(supportsAllDigests);
+            (void)(name);
+            (void)(author);
+                })
+                .isOk());
+    }
+
+    static void TearDownTestCase() { keymaster_.clear(); }
+
+    AuthorizationSet UserAuths() { return AuthorizationSetBuilder().Authorization(TAG_USER_ID, 7); }
+
+    ErrorCode GenerateKey(const AuthorizationSet& key_desc, HidlBuf* key_blob,
+                          KeyCharacteristics* key_characteristics) {
+        EXPECT_NE(key_blob, nullptr);
+        EXPECT_NE(key_characteristics, nullptr);
+        EXPECT_EQ(0U, key_blob->size());
+
+        ErrorCode error;
+        EXPECT_TRUE(keymaster_
+                        ->generateKey(key_desc.hidl_data(),
+                                      [&](ErrorCode hidl_error, const HidlBuf& hidl_key_blob,
+                                          const KeyCharacteristics& hidl_key_characteristics) {
+                                          error = hidl_error;
+                                          *key_blob = hidl_key_blob;
+                                          *key_characteristics = hidl_key_characteristics;
+                                      })
+                        .isOk());
+        // On error, blob & characteristics should be empty.
+        if (error != ErrorCode::OK) {
+            EXPECT_EQ(0U, key_blob->size());
+            EXPECT_EQ(0U, (key_characteristics->softwareEnforced.size() +
+                           key_characteristics->teeEnforced.size()));
+        }
+        return error;
+    }
+
+    ErrorCode ImportKey(const AuthorizationSet& key_desc, KeyFormat format,
+                        const string& key_material, HidlBuf* key_blob,
+                        KeyCharacteristics* key_characteristics) {
+        ErrorCode error;
+        EXPECT_TRUE(keymaster_
+                        ->importKey(key_desc.hidl_data(), format, HidlBuf(key_material),
+                                    [&](ErrorCode hidl_error, const HidlBuf& hidl_key_blob,
+                                        const KeyCharacteristics& hidl_key_characteristics) {
+                                        error = hidl_error;
+                                        *key_blob = hidl_key_blob;
+                                        *key_characteristics = hidl_key_characteristics;
+                                    })
+                        .isOk());
+        // On error, blob & characteristics should be empty.
+        if (error != ErrorCode::OK) {
+            EXPECT_EQ(0U, key_blob->size());
+            EXPECT_EQ(0U, (key_characteristics->softwareEnforced.size() +
+                           key_characteristics->teeEnforced.size()));
+        }
+        return error;
+    }
+
+    ErrorCode ExportKey(KeyFormat format, const HidlBuf& key_blob, const HidlBuf& client_id,
+                        const HidlBuf& app_data, HidlBuf* key_material) {
+        ErrorCode error;
+        EXPECT_TRUE(
+            keymaster_
+                ->exportKey(format, key_blob, client_id, app_data,
+                            [&](ErrorCode hidl_error_code, const HidlBuf& hidl_key_material) {
+                                error = hidl_error_code;
+                                *key_material = hidl_key_material;
+                            })
+                .isOk());
+        // On error, blob should be empty.
+        if (error != ErrorCode::OK) {
+            EXPECT_EQ(0U, key_material->size());
+        }
+        return error;
+    }
+
+    ErrorCode DeleteKey(HidlBuf* key_blob, bool keep_key_blob = false) {
+        auto rc = keymaster_->deleteKey(*key_blob);
+        if (!keep_key_blob) *key_blob = HidlBuf();
+        if (!rc.isOk()) return ErrorCode::UNKNOWN_ERROR;
+        return rc;
+    }
+
+    ErrorCode DeleteAllKeys() {
+        ErrorCode error = keymaster_->deleteAllKeys();
+        return error;
+    }
+
+    ErrorCode GetCharacteristics(const HidlBuf& key_blob, const HidlBuf& client_id,
+                                 const HidlBuf& app_data, KeyCharacteristics* key_characteristics) {
+        ErrorCode error = ErrorCode::UNKNOWN_ERROR;
+        EXPECT_TRUE(
+            keymaster_
+                ->getKeyCharacteristics(
+                    key_blob, client_id, app_data,
+                    [&](ErrorCode hidl_error, const KeyCharacteristics& hidl_key_characteristics) {
+                        error = hidl_error, *key_characteristics = hidl_key_characteristics;
+                    })
+                .isOk());
+        return error;
+    }
+
+    ErrorCode Begin(KeyPurpose purpose, const HidlBuf& key_blob, const AuthorizationSet& in_params,
+                    AuthorizationSet* out_params, OperationHandle* op_handle) {
+        SCOPED_TRACE("Begin");
+        ErrorCode error;
+        OperationHandle saved_handle = *op_handle;
+        EXPECT_TRUE(
+            keymaster_
+                ->begin(purpose, key_blob, in_params.hidl_data(),
+                        [&](ErrorCode hidl_error, const hidl_vec<KeyParameter>& hidl_out_params,
+                            uint64_t hidl_op_handle) {
+                            error = hidl_error;
+                            *out_params = hidl_out_params;
+                            *op_handle = hidl_op_handle;
+                        })
+                .isOk());
+        if (error != ErrorCode::OK) {
+            // Some implementations may modify *op_handle on error.
+            *op_handle = saved_handle;
+        }
+        return error;
+    }
+
+    ErrorCode Update(OperationHandle op_handle, const AuthorizationSet& in_params,
+                     const string& input, AuthorizationSet* out_params, string* output,
+                     size_t* input_consumed) {
+        SCOPED_TRACE("Update");
+        ErrorCode error;
+        EXPECT_TRUE(keymaster_
+                        ->update(op_handle, in_params.hidl_data(), HidlBuf(input),
+                                 [&](ErrorCode hidl_error, uint32_t hidl_input_consumed,
+                                     const hidl_vec<KeyParameter>& hidl_out_params,
+                                     const HidlBuf& hidl_output) {
+                                     error = hidl_error;
+                                     out_params->push_back(AuthorizationSet(hidl_out_params));
+                                     output->append(hidl_output.to_string());
+                                     *input_consumed = hidl_input_consumed;
+                                 })
+                        .isOk());
+        return error;
+    }
+
+    ErrorCode Finish(OperationHandle op_handle, const AuthorizationSet& in_params,
+                     const string& input, const string& signature, AuthorizationSet* out_params,
+                     string* output) {
+        SCOPED_TRACE("Finish");
+        ErrorCode error;
+        EXPECT_TRUE(
+            keymaster_
+                ->finish(op_handle, in_params.hidl_data(), HidlBuf(input), HidlBuf(signature),
+                         [&](ErrorCode hidl_error, const hidl_vec<KeyParameter>& hidl_out_params,
+                             const HidlBuf& hidl_output) {
+                             error = hidl_error;
+                             *out_params = hidl_out_params;
+                             output->append(hidl_output.to_string());
+                         })
+                .isOk());
+
+        return error;
+    }
+
+    ErrorCode Abort(OperationHandle op_handle) {
+        SCOPED_TRACE("Abort");
+        auto retval = keymaster_->abort(op_handle);
+        EXPECT_TRUE(retval.isOk());
+        return retval;
+    }
+
+    ErrorCode AttestKey(const HidlBuf& key_blob, const AuthorizationSet& attest_params,
+                        hidl_vec<hidl_vec<uint8_t>>* cert_chain) {
+        SCOPED_TRACE("AttestKey");
+        ErrorCode error;
+        auto rc = keymaster_->attestKey(
+            key_blob, attest_params.hidl_data(),
+            [&](ErrorCode hidl_error, const hidl_vec<hidl_vec<uint8_t>>& hidl_cert_chain) {
+                error = hidl_error;
+                *cert_chain = hidl_cert_chain;
+            });
+
+        EXPECT_TRUE(rc.isOk()) << rc.description();
+        if (!rc.isOk()) return ErrorCode::UNKNOWN_ERROR;
+
+        return error;
+    }
+
+private:
+     static sp<IKeymasterDevice> keymaster_;
+};
+
+sp<IKeymasterDevice> KeymasterTest::keymaster_;
+
+class KeymasterTagTest : public KeymasterTest {
+public:
+
+    /* Make a default signing operation with Ecdsa key using default operation
+       parameters and default message*/
+    ErrorCode DefaultEcdsaSigningOperation(const HidlBuf& key_blob) {
+	string message(24, 'a');
+	string signature;
+	AuthorizationSet in_params = AuthorizationSetBuilder().Digest(Digest::NONE);
+	AuthorizationSet out_params;
+	OperationHandle op_handle;
+
+	ErrorCode ret = Begin(KeyPurpose::SIGN, key_blob, in_params,
+			      &out_params, &op_handle);
+
+	if (ret != ErrorCode::OK) return ret;
+
+	ret = Finish(op_handle, AuthorizationSet(), message, signature, &out_params,
+		     &signature);
+
+	if (ret != ErrorCode::OK) return ret;
+
+	if (!out_params.empty())
+	    ret = ErrorCode:: UNKNOWN_ERROR;
+
+	return ret;
+    }
+};
+
+TEST_F(KeymasterTagTest, tag_MIN_SECONDS_BETWEEN_OPS) {
+    HidlBuf key_blobs[KM_MAX_USE_TIMERS+1];
+    KeyCharacteristics key_characteristics[KM_MAX_USE_TIMERS+1];
+    unsigned int seconds = 100;
+
+    for (unsigned int i = 0; i < sizeof(key_blobs)/sizeof(key_blobs[0]); i++) {
+        ASSERT_EQ(
+            ErrorCode::OK,
+            GenerateKey(AuthorizationSetBuilder()
+                            .EcdsaSigningKey(256)
+                            .Digest(Digest::NONE)
+                            .Authorization(TAG_NO_AUTH_REQUIRED)
+			    .Authorization(TAG_MIN_SECONDS_BETWEEN_OPS, seconds),
+                        &key_blobs[i], &key_characteristics[i]));
+    }
+
+    for (unsigned int i = 0; i < sizeof(key_blobs)/sizeof(key_blobs[0]) - 1; i++) {
+	ASSERT_EQ(ErrorCode::OK, DefaultEcdsaSigningOperation(key_blobs[i]));
+	ASSERT_EQ(ErrorCode::KEY_RATE_LIMIT_EXCEEDED, DefaultEcdsaSigningOperation(key_blobs[i]));
+    }
+
+     ASSERT_EQ(ErrorCode::TOO_MANY_OPERATIONS, DefaultEcdsaSigningOperation(key_blobs[KM_MAX_USE_TIMERS]));
+
+    /* Sleep for seconds - waiting TAG_MIN_SECONDS_BETWEEN_OPS seconds for our tables to get cleaned */
+    std::cout<<"Sleeping for " << seconds << " seconds\n";
+    usleep(seconds * 1000000);
+
+    ASSERT_EQ(ErrorCode::OK, DefaultEcdsaSigningOperation(key_blobs[0]));
+    ASSERT_EQ(ErrorCode::KEY_RATE_LIMIT_EXCEEDED, DefaultEcdsaSigningOperation(key_blobs[0]));
+}
+
+int main(int argc, char** argv) {
+    using android::hardware::keymaster::V3_0::test::KeymasterHidlEnvironment;
+    ::testing::AddGlobalTestEnvironment(KeymasterHidlEnvironment::Instance());
+    ::testing::InitGoogleTest(&argc, argv);
+    KeymasterHidlEnvironment::Instance()->init(&argc, argv);
+    for (int i = 1; i < argc; ++i) {
+        if (argv[i][0] == '-') {
+            if (std::string(argv[i]) == "--arm_deleteAllKeys") {
+                arm_deleteAllKeys = true;
+            }
+            if (std::string(argv[i]) == "--dump_attestations") {
+                dump_Attestations = true;
+            }
+        }
+    }
+    int status = RUN_ALL_TESTS();
+    ALOGI("Test result = %d", status);
+    return status;
+}
+
+}  // namespace test
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/keymaster_tags.h
+++ b/test/functional/keymaster_tags.h
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYSTEM_SECURITY_KEYSTORE_KEYMASTER_TAGS_H_
+#define SYSTEM_SECURITY_KEYSTORE_KEYMASTER_TAGS_H_
+
+/**
+ * This header contains various definitions that make working with keymaster tags safer and easier.
+ *
+ * It makes use of a fair amount of template metaprogramming. The metaprogramming serves the purpose
+ * of making it impossible to make certain classes of mistakes when operating on keymaster
+ * authorizations.  For example, it's an error to create a KeyParameter with tag == Tag::PURPOSE
+ * and then to assign Algorithm::RSA to algorithm element of its union. But because the user
+ * must choose the union field, there could be a mismatch which the compiler has now way to
+ * diagnose.
+ *
+ * The machinery in this header solves these problems by describing which union field corresponds
+ * to which Tag. Central to this mechanism is the template TypedTag. It has zero size and binds a
+ * numeric Tag to a type that the compiler understands. By means of the macro DECLARE_TYPED_TAG,
+ * we declare types for each of the tags defined in hardware/interfaces/keymaster/2.0/types.hal.
+ *
+ * The macro DECLARE_TYPED_TAG(name) generates a typename TAG_name_t and a zero sized instance
+ * TAG_name. Once these typed tags have been declared we define metafunctions mapping the each tag
+ * to its value c++ type and the correct union element of KeyParameter. This is done by means of
+ * the macros MAKE_TAG_*VALUE_ACCESSOR, which generates TypedTag2ValueType, a metafunction mapping
+ * a typed tag to the corresponding c++ type, and access function, accessTagValue returning a
+ * reference to the correct element of KeyParameter.
+ * E.g.:
+ *      given "KeyParameter param;" then "accessTagValue(TAG_PURPOSE, param)"
+ *      yields a reference to param.f.purpose
+ * If used in an assignment the compiler can now check the compatibility of the assigned value.
+ *
+ * For convenience we also provide the constructor like function Authorization().
+ * Authorization takes a typed tag and a value and checks at compile time whether the value given
+ * is suitable for the given tag. At runtime it creates a new KeyParameter initialized with the
+ * given tag and value and returns it by value.
+ *
+ * The second convenience function, authorizationValue, allows access to the KeyParameter value in
+ * a safe way. It takes a typed tag and a KeyParameter and returns a reference to the value wrapped
+ * by NullOr. NullOr has out-of-band information about whether it is save to access the wrapped
+ * reference.
+ * E.g.:
+ *      auto param = Authorization(TAG_ALGORITM, Algorithm::RSA);
+ *      auto value1 = authorizationValue(TAG_PURPOSE, param);
+ *      auto value2 = authorizationValue(TAG_ALGORITM, param);
+ * value1.isOk() yields false, but value2.isOk() yields true, thus value2.value() is save to access.
+ */
+
+#include <android/hardware/keymaster/3.0/IHwKeymasterDevice.h>
+#include <hardware/hw_auth_token.h>
+#include <type_traits>
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+// The following create the numeric values that KM_TAG_PADDING and KM_TAG_DIGEST used to have.  We
+// need these old values to be able to support old keys that use them.
+static const int32_t KM_TAG_DIGEST_OLD = static_cast<int32_t>(TagType::ENUM) | 5;
+static const int32_t KM_TAG_PADDING_OLD = static_cast<int32_t>(TagType::ENUM) | 7;
+
+constexpr TagType typeFromTag(Tag tag) {
+    return static_cast<TagType>(static_cast<uint32_t>(tag) & static_cast<uint32_t>(0xf0000000));
+}
+
+/**
+ * TypedTag is a templatized version of Tag, which provides compile-time checking of keymaster tag
+ * types. Instances are convertible to Tag, so they can be used wherever Tag is expected, and
+ * because they encode the tag type it's possible to create function overloads that only operate on
+ * tags with a particular type.
+ */
+template <TagType tag_type, Tag tag> struct TypedTag {
+    inline TypedTag() {
+        // Ensure that it's impossible to create a TypedTag instance whose 'tag' doesn't have type
+        // 'tag_type'.  Attempting to instantiate a tag with the wrong type will result in a compile
+        // error (no match for template specialization StaticAssert<false>), with no run-time cost.
+        static_assert(typeFromTag(tag) == tag_type, "mismatch between tag and tag_type");
+    }
+    constexpr operator Tag() { return tag; }
+    constexpr long maskedTag() {
+        return static_cast<long>(static_cast<uint32_t>(tag) & static_cast<uint32_t>(0x0fffffff));
+    }
+};
+
+template <Tag tag> struct Tag2TypedTag { typedef TypedTag<typeFromTag(tag), tag> type; };
+
+template <Tag tag> struct Tag2String;
+
+#define _TAGS_STRINGIFY(x) #x
+#define TAGS_STRINGIFY(x) _TAGS_STRINGIFY(x)
+
+#define DECLARE_TYPED_TAG(name)                                                                    \
+    typedef typename Tag2TypedTag<Tag::name>::type TAG_##name##_t;                                 \
+    extern TAG_##name##_t TAG_##name;                                                              \
+    template <> struct Tag2String<Tag::name> {                                                     \
+        static const char* value() { return "Tag::" TAGS_STRINGIFY(name); }                        \
+    }
+
+DECLARE_TYPED_TAG(INVALID);
+DECLARE_TYPED_TAG(KEY_SIZE);
+DECLARE_TYPED_TAG(MAC_LENGTH);
+DECLARE_TYPED_TAG(CALLER_NONCE);
+DECLARE_TYPED_TAG(MIN_MAC_LENGTH);
+DECLARE_TYPED_TAG(RSA_PUBLIC_EXPONENT);
+DECLARE_TYPED_TAG(ECIES_SINGLE_HASH_MODE);
+DECLARE_TYPED_TAG(INCLUDE_UNIQUE_ID);
+DECLARE_TYPED_TAG(ACTIVE_DATETIME);
+DECLARE_TYPED_TAG(ORIGINATION_EXPIRE_DATETIME);
+DECLARE_TYPED_TAG(USAGE_EXPIRE_DATETIME);
+DECLARE_TYPED_TAG(MIN_SECONDS_BETWEEN_OPS);
+DECLARE_TYPED_TAG(MAX_USES_PER_BOOT);
+DECLARE_TYPED_TAG(ALL_USERS);
+DECLARE_TYPED_TAG(USER_ID);
+DECLARE_TYPED_TAG(USER_SECURE_ID);
+DECLARE_TYPED_TAG(NO_AUTH_REQUIRED);
+DECLARE_TYPED_TAG(AUTH_TIMEOUT);
+DECLARE_TYPED_TAG(ALLOW_WHILE_ON_BODY);
+DECLARE_TYPED_TAG(ALL_APPLICATIONS);
+DECLARE_TYPED_TAG(APPLICATION_ID);
+DECLARE_TYPED_TAG(APPLICATION_DATA);
+DECLARE_TYPED_TAG(CREATION_DATETIME);
+DECLARE_TYPED_TAG(ROLLBACK_RESISTANT);
+DECLARE_TYPED_TAG(ROOT_OF_TRUST);
+DECLARE_TYPED_TAG(ASSOCIATED_DATA);
+DECLARE_TYPED_TAG(NONCE);
+DECLARE_TYPED_TAG(AUTH_TOKEN);
+DECLARE_TYPED_TAG(BOOTLOADER_ONLY);
+DECLARE_TYPED_TAG(OS_VERSION);
+DECLARE_TYPED_TAG(OS_PATCHLEVEL);
+DECLARE_TYPED_TAG(UNIQUE_ID);
+DECLARE_TYPED_TAG(ATTESTATION_CHALLENGE);
+DECLARE_TYPED_TAG(ATTESTATION_APPLICATION_ID);
+DECLARE_TYPED_TAG(RESET_SINCE_ID_ROTATION);
+
+DECLARE_TYPED_TAG(PURPOSE);
+DECLARE_TYPED_TAG(ALGORITHM);
+DECLARE_TYPED_TAG(BLOCK_MODE);
+DECLARE_TYPED_TAG(DIGEST);
+DECLARE_TYPED_TAG(PADDING);
+DECLARE_TYPED_TAG(BLOB_USAGE_REQUIREMENTS);
+DECLARE_TYPED_TAG(ORIGIN);
+DECLARE_TYPED_TAG(USER_AUTH_TYPE);
+DECLARE_TYPED_TAG(KDF);
+DECLARE_TYPED_TAG(EC_CURVE);
+
+template <typename... Elems> struct MetaList {};
+
+using all_tags_t = MetaList<
+    TAG_INVALID_t, TAG_KEY_SIZE_t, TAG_MAC_LENGTH_t, TAG_CALLER_NONCE_t, TAG_MIN_MAC_LENGTH_t,
+    TAG_RSA_PUBLIC_EXPONENT_t, TAG_ECIES_SINGLE_HASH_MODE_t, TAG_INCLUDE_UNIQUE_ID_t,
+    TAG_ACTIVE_DATETIME_t, TAG_ORIGINATION_EXPIRE_DATETIME_t, TAG_USAGE_EXPIRE_DATETIME_t,
+    TAG_MIN_SECONDS_BETWEEN_OPS_t, TAG_MAX_USES_PER_BOOT_t, TAG_ALL_USERS_t, TAG_USER_ID_t,
+    TAG_USER_SECURE_ID_t, TAG_NO_AUTH_REQUIRED_t, TAG_AUTH_TIMEOUT_t, TAG_ALLOW_WHILE_ON_BODY_t,
+    TAG_ALL_APPLICATIONS_t, TAG_APPLICATION_ID_t, TAG_APPLICATION_DATA_t, TAG_CREATION_DATETIME_t,
+    TAG_ROLLBACK_RESISTANT_t, TAG_ROOT_OF_TRUST_t, TAG_ASSOCIATED_DATA_t, TAG_NONCE_t,
+    TAG_AUTH_TOKEN_t, TAG_BOOTLOADER_ONLY_t, TAG_OS_VERSION_t, TAG_OS_PATCHLEVEL_t, TAG_UNIQUE_ID_t,
+    TAG_ATTESTATION_CHALLENGE_t, TAG_ATTESTATION_APPLICATION_ID_t, TAG_RESET_SINCE_ID_ROTATION_t,
+    TAG_PURPOSE_t, TAG_ALGORITHM_t, TAG_BLOCK_MODE_t, TAG_DIGEST_t, TAG_PADDING_t,
+    TAG_BLOB_USAGE_REQUIREMENTS_t, TAG_ORIGIN_t, TAG_USER_AUTH_TYPE_t, TAG_KDF_t, TAG_EC_CURVE_t>;
+
+/* implementation in keystore_utils.cpp */
+extern const char* stringifyTag(Tag tag);
+
+template <typename TypedTagType> struct TypedTag2ValueType;
+
+#define MAKE_TAG_VALUE_ACCESSOR(tag_type, field_name)                                              \
+    template <Tag tag> struct TypedTag2ValueType<TypedTag<tag_type, tag>> {                        \
+        typedef decltype(static_cast<KeyParameter*>(nullptr)->field_name) type;                    \
+    };                                                                                             \
+    template <Tag tag>                                                                             \
+    inline auto accessTagValue(TypedTag<tag_type, tag>, const KeyParameter& param)                 \
+        ->const decltype(param.field_name)& {                                                      \
+        return param.field_name;                                                                   \
+    }                                                                                              \
+    template <Tag tag>                                                                             \
+    inline auto accessTagValue(TypedTag<tag_type, tag>, KeyParameter& param)                       \
+        ->decltype(param.field_name)& {                                                            \
+        return param.field_name;                                                                   \
+    }
+
+MAKE_TAG_VALUE_ACCESSOR(TagType::ULONG, f.longInteger)
+MAKE_TAG_VALUE_ACCESSOR(TagType::ULONG_REP, f.longInteger)
+MAKE_TAG_VALUE_ACCESSOR(TagType::DATE, f.dateTime)
+MAKE_TAG_VALUE_ACCESSOR(TagType::UINT, f.integer)
+MAKE_TAG_VALUE_ACCESSOR(TagType::UINT_REP, f.integer)
+MAKE_TAG_VALUE_ACCESSOR(TagType::BOOL, f.boolValue)
+MAKE_TAG_VALUE_ACCESSOR(TagType::BYTES, blob)
+MAKE_TAG_VALUE_ACCESSOR(TagType::BIGNUM, blob)
+
+#define MAKE_TAG_ENUM_VALUE_ACCESSOR(typed_tag, field_name)                                        \
+    template <> struct TypedTag2ValueType<decltype(typed_tag)> {                                   \
+        typedef decltype(static_cast<KeyParameter*>(nullptr)->field_name) type;                    \
+    };                                                                                             \
+    inline auto accessTagValue(decltype(typed_tag), const KeyParameter& param)                     \
+        ->const decltype(param.field_name)& {                                                      \
+        return param.field_name;                                                                   \
+    }                                                                                              \
+    inline auto accessTagValue(decltype(typed_tag), KeyParameter& param)                           \
+        ->decltype(param.field_name)& {                                                            \
+        return param.field_name;                                                                   \
+    }
+
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_ALGORITHM, f.algorithm)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_BLOB_USAGE_REQUIREMENTS, f.keyBlobUsageRequirements)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_BLOCK_MODE, f.blockMode)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_DIGEST, f.digest)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_EC_CURVE, f.ecCurve)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_KDF, f.keyDerivationFunction)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_ORIGIN, f.origin)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_PADDING, f.paddingMode)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_PURPOSE, f.purpose)
+MAKE_TAG_ENUM_VALUE_ACCESSOR(TAG_USER_AUTH_TYPE, f.hardwareAuthenticatorType)
+
+template <TagType tag_type, Tag tag, typename ValueT>
+inline KeyParameter makeKeyParameter(TypedTag<tag_type, tag> ttag, ValueT&& value) {
+    KeyParameter param;
+    param.tag = tag;
+    param.f.longInteger = 0;
+    accessTagValue(ttag, param) = std::forward<ValueT>(value);
+    return param;
+}
+
+// the boolean case
+template <Tag tag> inline KeyParameter makeKeyParameter(TypedTag<TagType::BOOL, tag>) {
+    KeyParameter param;
+    param.tag = tag;
+    param.f.boolValue = true;
+    return param;
+}
+
+template <typename... Pack> struct FirstOrNoneHelper;
+template <typename First> struct FirstOrNoneHelper<First> { typedef First type; };
+template <> struct FirstOrNoneHelper<> {
+    struct type {};
+};
+
+template <typename... Pack> using FirstOrNone = typename FirstOrNoneHelper<Pack...>::type;
+
+template <TagType tag_type, Tag tag, typename... Args>
+inline KeyParameter Authorization(TypedTag<tag_type, tag> ttag, Args&&... args) {
+    static_assert(tag_type != TagType::BOOL || (sizeof...(args) == 0),
+                  "TagType::BOOL Authorizations do not take parameters. Presence is truth.");
+    static_assert(tag_type == TagType::BOOL || (sizeof...(args) == 1),
+                  "Authorization other then TagType::BOOL take exactly one parameter.");
+    static_assert(
+        tag_type == TagType::BOOL ||
+            std::is_convertible<std::remove_cv_t<std::remove_reference_t<FirstOrNone<Args...>>>,
+                                typename TypedTag2ValueType<TypedTag<tag_type, tag>>::type>::value,
+        "Invalid argument type for given tag.");
+
+    return makeKeyParameter(ttag, std::forward<Args>(args)...);
+}
+
+/**
+ * This class wraps a (mostly return) value and stores whether or not the wrapped value is valid out
+ * of band. Note that if the wrapped value is a reference it is unsafe to access the value if
+ * !isOk(). If the wrapped type is a pointer or value and !isOk(), it is still safe to access the
+ * wrapped value. In this case the pointer will be NULL though, and the value will be default
+ * constructed.
+ */
+template <typename ValueT> class NullOr {
+    template <typename T> struct reference_initializer {
+        static T&& init() { return *static_cast<std::remove_reference_t<T>*>(nullptr); }
+    };
+    template <typename T> struct pointer_initializer {
+        static T init() { return nullptr; }
+    };
+    template <typename T> struct value_initializer {
+        static T init() { return T(); }
+    };
+    template <typename T>
+    using initializer_t =
+        std::conditional_t<std::is_lvalue_reference<T>::value, reference_initializer<T>,
+                           std::conditional_t<std::is_pointer<T>::value, pointer_initializer<T>,
+                                              value_initializer<T>>>;
+
+  public:
+    NullOr() : value_(initializer_t<ValueT>::init()), null_(true) {}
+    NullOr(ValueT&& value) : value_(std::forward<ValueT>(value)), null_(false) {}
+
+    bool isOk() const { return !null_; }
+
+    const ValueT& value() const & { return value_; }
+    ValueT& value() & { return value_; }
+    ValueT&& value() && { return std::move(value_); }
+
+  private:
+    ValueT value_;
+    bool null_;
+};
+
+template <typename T> std::remove_reference_t<T> NullOrOr(NullOr<T>&& v) {
+    if (v.isOk()) return v;
+    return {};
+}
+
+template <typename Head, typename... Tail>
+std::remove_reference_t<Head> NullOrOr(Head&& head, Tail&&... tail) {
+    if (head.isOk()) return head;
+    return NullOrOr(std::forward<Tail>(tail)...);
+}
+
+template <typename Default, typename Wrapped>
+std::remove_reference_t<Wrapped> defaultOr(NullOr<Wrapped>&& optional, Default&& def) {
+    static_assert(std::is_convertible<std::remove_reference_t<Default>,
+                                      std::remove_reference_t<Wrapped>>::value,
+                  "Type of default value must match the type wrapped by NullOr");
+    if (optional.isOk()) return optional.value();
+    return def;
+}
+
+template <TagType tag_type, Tag tag>
+inline NullOr<const typename TypedTag2ValueType<TypedTag<tag_type, tag>>::type&>
+authorizationValue(TypedTag<tag_type, tag> ttag, const KeyParameter& param) {
+    if (tag != param.tag) return {};
+    return accessTagValue(ttag, param);
+}
+
+inline const char* stringify(Digest digest) {
+    switch (digest) {
+    case Digest::NONE:
+        return "None";
+    case Digest::MD5:
+        return "Md5";
+    case Digest::SHA1:
+        return "Sha1";
+    case Digest::SHA_2_224:
+        return "Sha224";
+    case Digest::SHA_2_256:
+        return "Sha256";
+    case Digest::SHA_2_384:
+        return "Sha384";
+    case Digest::SHA_2_512:
+        return "Sha512";
+    }
+    return "UNKNOWN DIGEST!";
+}
+
+inline const char* stringify(Algorithm algorithm) {
+    switch (algorithm) {
+    case Algorithm::RSA:
+        return "Rsa";
+    case Algorithm::EC:
+        return "Ec";
+    case Algorithm::AES:
+        return "Aes";
+    case Algorithm::HMAC:
+        return "Hmac";
+    }
+    return "UNKNOWN ALGORITHM";
+}
+
+inline const char* stringify(BlockMode block_mode) {
+    switch (block_mode) {
+    case BlockMode::ECB:
+        return "Ecb";
+    case BlockMode::CBC:
+        return "Cbc";
+    case BlockMode::CTR:
+        return "Ctr";
+    case BlockMode::GCM:
+        return "Gcm";
+    }
+    return "UNKNOWN BLOCK MODE";
+}
+
+inline const char* stringify(PaddingMode padding) {
+    switch (padding) {
+    case PaddingMode::NONE:
+        return "None";
+    case PaddingMode::RSA_OAEP:
+        return "RsaOaep";
+    case PaddingMode::RSA_PSS:
+        return "RsaPss";
+    case PaddingMode::RSA_PKCS1_1_5_ENCRYPT:
+        return "RsaPkcs115Encrypt";
+    case PaddingMode::RSA_PKCS1_1_5_SIGN:
+        return "RsaPkcs115Sign";
+    case PaddingMode::PKCS7:
+        return "Pkcs7";
+    }
+    return "UNKNOWN PADDING MODE";
+}
+
+inline const char* stringify(KeyOrigin origin) {
+    switch (origin) {
+    case KeyOrigin::GENERATED:
+        return "Generated";
+    case KeyOrigin::DERIVED:
+        return "Derived";
+    case KeyOrigin::IMPORTED:
+        return "Imported";
+    case KeyOrigin::UNKNOWN:
+        return "UNKNOWN (keymaster0 didn't record it)";
+    }
+    return "UNKOWN KEY ORIGIN VALUE";
+}
+
+inline const char* stringify(KeyPurpose purpose) {
+    switch (purpose) {
+    case KeyPurpose::ENCRYPT:
+        return "Encrypt";
+    case KeyPurpose::DECRYPT:
+        return "Decrypt";
+    case KeyPurpose::SIGN:
+        return "Sign";
+    case KeyPurpose::VERIFY:
+        return "Verify";
+    case KeyPurpose::DERIVE_KEY:
+        return "DeriveKey";
+    case KeyPurpose::WRAP_KEY:
+        return "WrapKey";
+    };
+    return "UNKNOWN KEY PURPOSE";
+}
+
+inline const char* stringify(EcCurve curve) {
+    switch (curve) {
+    case EcCurve::P_224:
+        return "P_224";
+    case EcCurve::P_256:
+        return "P_256";
+    case EcCurve::P_384:
+        return "P_384";
+    case EcCurve::P_521:
+        return "P_521";
+    }
+    return "UNKNOWN EC CURVE";
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android
+
+#endif  // SYSTEM_SECURITY_KEYSTORE_KEYMASTER_TAGS_H_

--- a/test/functional/keystore_tags_utils.cpp
+++ b/test/functional/keystore_tags_utils.cpp
@@ -1,0 +1,50 @@
+/*
+**
+** Copyright 2016, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "keymaster_tags.h"
+
+namespace android {
+namespace hardware {
+namespace keymaster {
+namespace V3_0 {
+
+template <typename TagList> struct TagStringifier;
+
+template <typename... Tags> struct TagStringifier<MetaList<Tags...>> {
+    template <TagType tag_type, Tag tag>
+    static TypedTag<tag_type, tag> chooseString(TypedTag<tag_type, tag> ttag, Tag runtime_tag,
+                                                const char** result) {
+        if (tag == runtime_tag) {
+            *result = Tag2String<tag>::value();
+        }
+        return ttag;
+    }
+    static const char* stringify(Tag tag) {
+        const char* result = "unknown tag";
+        [](Tags&&...) {}(chooseString(Tags(), tag, &result)...);
+        return result;
+    }
+};
+
+const char* stringifyTag(Tag tag) {
+    return TagStringifier<all_tags_t>::stringify(tag);
+}
+
+}  // namespace V3_0
+}  // namespace keymaster
+}  // namespace hardware
+}  // namespace android

--- a/test/functional/openssl_utils.h
+++ b/test/functional/openssl_utils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+template <typename T, void (*F)(T*)> struct UniquePtrDeleter {
+    void operator()(T* p) const { F(p); }
+};
+
+typedef UniquePtrDeleter<EVP_PKEY, EVP_PKEY_free> EVP_PKEY_Delete;
+
+#define MAKE_OPENSSL_PTR_TYPE(type)                                                                \
+    typedef std::unique_ptr<type, UniquePtrDeleter<type, type##_free>> type##_Ptr;
+
+MAKE_OPENSSL_PTR_TYPE(ASN1_OBJECT)
+MAKE_OPENSSL_PTR_TYPE(EVP_PKEY)
+MAKE_OPENSSL_PTR_TYPE(RSA)
+MAKE_OPENSSL_PTR_TYPE(X509)
+MAKE_OPENSSL_PTR_TYPE(BN_CTX)
+
+typedef std::unique_ptr<BIGNUM, UniquePtrDeleter<BIGNUM, BN_free>> BIGNUM_Ptr;
+
+inline const EVP_MD* openssl_digest(android::hardware::keymaster::V3_0::Digest digest) {
+    switch (digest) {
+    case android::hardware::keymaster::V3_0::Digest::NONE:
+        return nullptr;
+    case android::hardware::keymaster::V3_0::Digest::MD5:
+        return EVP_md5();
+    case android::hardware::keymaster::V3_0::Digest::SHA1:
+        return EVP_sha1();
+    case android::hardware::keymaster::V3_0::Digest::SHA_2_224:
+        return EVP_sha224();
+    case android::hardware::keymaster::V3_0::Digest::SHA_2_256:
+        return EVP_sha256();
+    case android::hardware::keymaster::V3_0::Digest::SHA_2_384:
+        return EVP_sha384();
+    case android::hardware::keymaster::V3_0::Digest::SHA_2_512:
+        return EVP_sha512();
+    }
+    return nullptr;
+}


### PR DESCRIPTION
Thgis PR fixes non-working logic for tags:
- MIN_SECONDS_BETWEEN_OPS [1]
- MAX_USES_PER_BOOT [2]

Test class based on google VTS is added.
2 test cases for [1] and  [2] logic are added.

TA Details:
 - tables for storing keys were not working properly. Key pointers were only saved, instead of whole key data. This is fixed: now unique key id (represented as AES GCM tag of encrypted key) is used to identify and store required key metadata. 
 - previous logic can not be used (just fix it to store the key data instead of the pointers only) -  the same raw key data can be used for generation of multiple key objects with different parameters (tags). In this case different key objects will be identified as one.
- MIN_SECONDS_BETWEEN_OPS  table was expanded to 32 keys to meet minimal google requirements
- both tables logic was reworked to correctly handle all scenarios

Test details:
- as base source code for testing google VTS was used (everything was already implemented there, no need to do it once more). this will also allow us to integrate VTS test cases in future if needed
- 2 test cases were added to cover [1] and [2] logic. 

1. https://source.android.com/security/keystore/tags#min_seconds_between_ops
2. https://source.android.com/security/keystore/tags#max_uses_per_boot