### PR TITLE
ta: master_crypto: fix aes gcm iv (nonce) length

### DIFF
--- a/keymaster/ta/include/master_crypto.h
+++ b/keymaster/ta/include/master_crypto.h
@@ -18,11 +18,8 @@
 #ifndef ANDROID_OPTEE_MASTER_CRYPTO_H
 #define ANDROID_OPTEE_MASTER_CRYPTO_H
 
-#define KEY_SIZE 128U
 #define KEY_LENGTH 16
-#define TAG_SIZE 128U
 #define TAG_LENGTH 16
-#define IV_SIZE 96U
 #define IV_LENGTH 12
 
 #include <tee_internal_api.h>

--- a/keymaster/ta/include/master_crypto.h
+++ b/keymaster/ta/include/master_crypto.h
@@ -22,6 +22,8 @@
 #define KEY_LENGTH 16
 #define TAG_SIZE 128U
 #define TAG_LENGTH 16
+#define IV_SIZE 96U
+#define IV_LENGTH 12
 
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>

--- a/keymaster/ta/master_crypto.c
+++ b/keymaster/ta/master_crypto.c
@@ -21,7 +21,7 @@
 //and also used as HBK (hardware-bound private key) during attestation
 
 static uint8_t objID[] = {0xa7U, 0x62U, 0xcfU, 0x11U};
-static uint8_t iv[KEY_LENGTH];
+static uint8_t iv[IV_LENGTH];
 
 TEE_Result TA_open_secret_key(TEE_ObjectHandle *secretKey)
 {
@@ -53,7 +53,7 @@ TEE_Result TA_open_secret_key(TEE_ObjectHandle *secretKey)
 
 		//IV size is fixed
 		res = TEE_ReadObjectData(object, iv, sizeof(iv), &readSize);
-		if (res != TEE_SUCCESS || readSize != KEY_LENGTH) {
+		if (res != TEE_SUCCESS || readSize != IV_LENGTH) {
 			EMSG("Failed to read IV, res = %x", res);
 			goto close;
 		}

--- a/keymaster/ta/master_crypto.c
+++ b/keymaster/ta/master_crypto.c
@@ -16,6 +16,7 @@
  */
 
 #include "master_crypto.h"
+#include "shift.h"
 
 //Master key for encryption/decryption of all CA's keys,
 //and also used as HBK (hardware-bound private key) during attestation
@@ -61,7 +62,8 @@ TEE_Result TA_open_secret_key(TEE_ObjectHandle *secretKey)
 		TEE_InitRefAttribute(&attrs[0], TEE_ATTR_SECRET_VALUE,
 				keyData, sizeof(keyData));
 
-		res = TEE_AllocateTransientObject(TEE_TYPE_AES, KEY_SIZE, &masterKey);
+		res = TEE_AllocateTransientObject(TEE_TYPE_AES,
+				KEY_LENGTH * BITS_IN_BYTE, &masterKey);
 		if (res == TEE_SUCCESS) {
 			res = TEE_PopulateTransientObject(masterKey, attrs,
 					sizeof(attrs)/sizeof(TEE_Attribute));
@@ -180,7 +182,7 @@ TEE_Result TA_execute(uint8_t *data, const size_t size, const uint32_t mode)
 		EMSG("Failed to set secret key, res=%x", res);
 		goto free_op;
 	}
-	TEE_AEInit(op, iv, sizeof(iv), TAG_SIZE, 0, 0);
+	TEE_AEInit(op, iv, sizeof(iv), TAG_LENGTH * BITS_IN_BYTE, 0, 0);
 	if (res == TEE_SUCCESS && size > 0) {
 		if (mode == TEE_MODE_ENCRYPT) {
 			DMSG("tagLen = %u", tagLen);


### PR DESCRIPTION
Per [1], "For IVs, it is recommended that implementations restrict
support to the length of 96 bits, to promote interoperability,
efficiency, and simplicity of design."

[LINK] [1] https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
Signed-off-by: Victor Chong <victor.chong@linaro.org>