### PR TITLE
km: ta: check addr_indirect_data before free

### DIFF
--- a/keymaster/ta/parsel.c
+++ b/keymaster/ta/parsel.c
@@ -711,7 +711,8 @@ int TA_serialize_auth_set(uint8_t *out, uint8_t *out_end,
 
 exit:
 	DMSG("auth_set size: %d", serialized_auth_set_size);
-	TEE_Free(addr_indirect_data);
+        if (addr_indirect_data)
+                TEE_Free(addr_indirect_data);
 	if (!*oob &&
 	    TA_is_out_of_bounds(start, out_end, serialized_auth_set_size)) {
 		EMSG("Exceeding end of output buffer");


### PR DESCRIPTION
This patch check if addr_indirect_data is not NULL before call TEE_Free.

Signed-off-by: Julien Masson <jmasson@baylibre.com>
Signed-off-by: Safae Ouajih <souajih@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
