### PR TITLE
keymaster: Remove use of hardcoded PAGE_SIZE 4096

### DIFF
--- a/keymaster/include/optee_keymaster/ipc/optee_keymaster_ipc.h
+++ b/keymaster/include/optee_keymaster/ipc/optee_keymaster_ipc.h
@@ -23,8 +23,8 @@
 
 __BEGIN_DECLS
 
-const uint32_t OPTEE_KEYMASTER_RECV_BUF_SIZE = 2 * PAGE_SIZE;
-const uint32_t OPTEE_KEYMASTER_SEND_BUF_SIZE = 2 * PAGE_SIZE;
+const uint32_t OPTEE_KEYMASTER_RECV_BUF_SIZE = 2 * getpagesize();
+const uint32_t OPTEE_KEYMASTER_SEND_BUF_SIZE = 2 * getpagesize();
 
 int optee_keymaster_connect(void);
 int optee_keymaster_call(uint32_t cmd, void* in, uint32_t in_size, uint8_t* out,


### PR DESCRIPTION
bionic hard-codes the PAGE_SIZE macro as 4096. This is going away as Android begins to support larger page sizes [1]

Remove the usage of this hard-coded value by using getpagesize() instead as recommended by the doc [2].

[1] https://source.android.com/docs/core/architecture/16kb-page-size/16kb
[2] https://source.android.com/docs/core/architecture/16kb-page-size/getting-page-size
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

This has been build-tested on [android-platform-15.0.0_r1](https://android.googlesource.com/platform/manifest/+/refs/tags/android-platform-15.0.0_r1) tag with a Texas Instruments AM62Px SK EVM board.

Before change:
```
external/kmgk/keymaster/include/optee_keymaster/ipc/optee_keymaster_ipc.h:26:52: error: use of undeclared identifier 'PAGE_SIZE'
   26 | const uint32_t OPTEE_KEYMASTER_RECV_BUF_SIZE = 2 * PAGE_SIZE;
      |                                                    ^
external/kmgk/keymaster/include/optee_keymaster/ipc/optee_keymaster_ipc.h:27:52: error: use of undeclared identifier 'PAGE_SIZE'
   27 | const uint32_t OPTEE_KEYMASTER_SEND_BUF_SIZE = 2 * PAGE_SIZE;
      |                                                    ^
2 errors generated.
[ 15% 2/13 4s remaining] //external/kmgk/keymaster:android.hardware.security.keymint-service.optee clang++ OpteeKeymaster.cpp
```

After change: build is sucessful.

Note I have not functionally-tested this since we use a fork which has a bit of advance on the upstream project (https://gitlab.baylibre.com/baylibre/ti/android/aosp/external/kmgk)
I have functionally tested this on the above fork: we can boot Android 15 and decrypt `userdata` partition using kmgk.